### PR TITLE
From QPlainTextEdit to QLineEdit

### DIFF
--- a/FILE201/Main.py
+++ b/FILE201/Main.py
@@ -7,7 +7,7 @@ from FILE201.fontLoader import load_fonts
 def main():
     app = QApplication(sys.argv)
     connection = create_connection()
-    load_fonts()
+    #load_fonts()
 
     # Check if the connection was successful
     if connection is None:

--- a/FILE201/Other_Information/otherInformationModal.py
+++ b/FILE201/Other_Information/otherInformationModal.py
@@ -2,24 +2,12 @@ import sys
 import os
 
 from PyQt5 import QtWidgets, QtCore
-from PyQt5.QtWidgets import QDialog, QPlainTextEdit
+from PyQt5.QtWidgets import QDialog, QLineEdit
 from PyQt5.uic import loadUi
 from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QIntValidator # Founded a new library
 
 from FILE201.file201_Function.modalFunction import modalFunction
-
-class NumberOnlyPlainTextEdit(QPlainTextEdit):
-    def __init__(self, parent=None):
-        super(NumberOnlyPlainTextEdit, self).__init__(parent)
-
-    def keyPressEvent(self, event):
-        key = event.key()
-        # Allow only numbers, backspace, delete, left arrow, right arrow
-        if key in (Qt.Key_0, Qt.Key_1, Qt.Key_2, Qt.Key_3, Qt.Key_4, Qt.Key_5, Qt.Key_6, Qt.Key_7, Qt.Key_8, Qt.Key_9,
-                   Qt.Key_Backspace, Qt.Key_Delete, Qt.Key_Left, Qt.Key_Right):
-            super(NumberOnlyPlainTextEdit, self).keyPressEvent(event)
-        else:
-            event.ignore()
 
 class personalModal(QDialog):
     def __init__(self):
@@ -39,24 +27,25 @@ class personalModal(QDialog):
         self.saveBTN.clicked.connect(self.functions.save_Employee)
         self.revertBTN.clicked.connect(self.functions.revert_Employee)
 
-        self.apply_number_only_validation(self.sssTextEdit)
-        self.apply_number_only_validation(self.pagibigTextEdit)
-        self.apply_number_only_validation(self.philHealthTextEdit)
-        self.apply_number_only_validation(self.tinTextEdit)
+        self.set_validators()
+        self.set_keyboard_shortcut()
 
     def set_current_date_to_all_date_edits(self, current_date):
         for widget in self.findChildren(QtWidgets.QDateEdit):
             widget.setDate(current_date)
 
-    def apply_number_only_validation(self, text_edit):
-        text_edit.installEventFilter(self)
+    def set_validators(self):
+        int_validator = QIntValidator()
 
-    def eventFilter(self, source, event):
-        if isinstance(source, QPlainTextEdit) and source.objectName() in ['sssTextEdit', 'pagibigTextEdit', 'philHealthTextEdit', 'tinTextEdit']:
-            if event.type() == QtCore.QEvent.KeyPress:
-                key = event.key()
-                if key in (Qt.Key_0, Qt.Key_1, Qt.Key_2, Qt.Key_3, Qt.Key_4, Qt.Key_5, Qt.Key_6, Qt.Key_7, Qt.Key_8, Qt.Key_9,
-                           Qt.Key_Backspace, Qt.Key_Delete, Qt.Key_Left, Qt.Key_Right):
-                    return super(personalModal, self).eventFilter(source, event)
-        return super(personalModal, self).eventFilter(source, event)
+        self.txtZip.setValidator(int_validator)
+        self.txtPhone.setValidator(int_validator)
+        self.txtHeight.setValidator(int_validator)
+        self.txtWeight.setValidator(int_validator)
+        self.sssTextEdit.setValidator(int_validator)
+        self.pagibigTextEdit.setValidator(int_validator)
+        self.philHealthTextEdit.setValidator(int_validator)
+        self.tinTextEdit.setValidator(int_validator)
 
+    def set_keyboard_shortcut(self):
+        self.shortcut = QtWidgets.QShortcut(Qt.Key_Escape, self)
+        self.shortcut.activated.connect(self.close)

--- a/FILE201/Other_Information/personalInformation.ui
+++ b/FILE201/Other_Information/personalInformation.ui
@@ -230,9 +230,9 @@ border: 1px solid black</string>
    <widget class="QLabel" name="lblTitle_2">
     <property name="geometry">
      <rect>
-      <x>4</x>
+      <x>10</x>
       <y>260</y>
-      <width>331</width>
+      <width>310</width>
       <height>41</height>
      </rect>
     </property>
@@ -251,18 +251,18 @@ border: 1px solid black</string>
      <string notr="true">color: white; border: none; background: none;</string>
     </property>
     <property name="text">
-     <string>Employee Name</string>
+     <string>Employee Name:</string>
     </property>
     <property name="alignment">
-     <set>Qt::AlignCenter</set>
+     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
     </property>
    </widget>
    <widget class="QLabel" name="lblTitle_3">
     <property name="geometry">
      <rect>
-      <x>98</x>
-      <y>290</y>
-      <width>170</width>
+      <x>10</x>
+      <y>341</y>
+      <width>311</width>
       <height>41</height>
      </rect>
     </property>
@@ -279,6 +279,66 @@ border: 1px solid black</string>
     </property>
     <property name="text">
      <string>ID No.</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="nameDisplay">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>300</y>
+      <width>291</width>
+      <height>41</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <family>Poppins</family>
+      <pointsize>14</pointsize>
+      <weight>50</weight>
+      <bold>false</bold>
+     </font>
+    </property>
+    <property name="layoutDirection">
+     <enum>Qt::LeftToRight</enum>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: white; border: none; background: none;</string>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="idDisplay">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>381</y>
+      <width>291</width>
+      <height>41</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <family>Poppins</family>
+      <pointsize>14</pointsize>
+      <weight>50</weight>
+      <bold>false</bold>
+     </font>
+    </property>
+    <property name="layoutDirection">
+     <enum>Qt::LeftToRight</enum>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: white; border: none; background: none;</string>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
     </property>
    </widget>
   </widget>
@@ -319,7 +379,7 @@ border: 1px solid black</string>
     <property name="geometry">
      <rect>
       <x>0</x>
-      <y>0</y>
+      <y>-850</y>
       <width>1218</width>
       <height>1788</height>
      </rect>
@@ -417,6 +477,12 @@ border: 1px solid black;
 }
 QLabel{
 border: none;
+}
+
+QLineEdit{
+background-color: rgb(255, 255, 255);
+border-radius: 5px;
+border: 1px solid black;
 }</string>
         </property>
         <property name="frameShape">
@@ -442,30 +508,6 @@ border: none;
          </property>
          <property name="text">
           <string>SSS</string>
-         </property>
-        </widget>
-        <widget class="QPlainTextEdit" name="sssTextEdit">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>52</y>
-           <width>214</width>
-           <height>31</height>
-          </rect>
-         </property>
-         <property name="font">
-          <font>
-           <family>Poppins</family>
-           <pointsize>10</pointsize>
-          </font>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-         </property>
-         <property name="verticalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
          </property>
         </widget>
         <widget class="QLabel" name="pagibigLabel">
@@ -525,11 +567,11 @@ border: 1px solid black;</string>
           <string>Phil Health</string>
          </property>
         </widget>
-        <widget class="QPlainTextEdit" name="philHealthTextEdit">
+        <widget class="QLineEdit" name="sssTextEdit">
          <property name="geometry">
           <rect>
            <x>10</x>
-           <y>178</y>
+           <y>50</y>
            <width>214</width>
            <height>31</height>
           </rect>
@@ -540,20 +582,18 @@ border: 1px solid black;</string>
            <pointsize>10</pointsize>
           </font>
          </property>
-         <property name="styleSheet">
-          <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
+         <property name="autoFillBackground">
+          <bool>false</bool>
          </property>
-         <property name="verticalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
+         <property name="maxLength">
+          <number>15</number>
          </property>
         </widget>
-        <widget class="QPlainTextEdit" name="pagibigTextEdit">
+        <widget class="QLineEdit" name="philHealthTextEdit">
          <property name="geometry">
           <rect>
            <x>10</x>
-           <y>116</y>
+           <y>180</y>
            <width>214</width>
            <height>31</height>
           </rect>
@@ -564,20 +604,18 @@ border: 1px solid black;</string>
            <pointsize>10</pointsize>
           </font>
          </property>
-         <property name="styleSheet">
-          <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
+         <property name="autoFillBackground">
+          <bool>false</bool>
          </property>
-         <property name="verticalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
+         <property name="maxLength">
+          <number>15</number>
          </property>
         </widget>
-        <widget class="QPlainTextEdit" name="tinTextEdit">
+        <widget class="QLineEdit" name="pagibigTextEdit">
          <property name="geometry">
           <rect>
            <x>10</x>
-           <y>242</y>
+           <y>114</y>
            <width>214</width>
            <height>31</height>
           </rect>
@@ -588,13 +626,33 @@ border: 1px solid black;</string>
            <pointsize>10</pointsize>
           </font>
          </property>
-         <property name="styleSheet">
-          <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
+         <property name="autoFillBackground">
+          <bool>false</bool>
          </property>
-         <property name="verticalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
+         <property name="maxLength">
+          <number>15</number>
+         </property>
+        </widget>
+        <widget class="QLineEdit" name="tinTextEdit">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>240</y>
+           <width>214</width>
+           <height>31</height>
+          </rect>
+         </property>
+         <property name="font">
+          <font>
+           <family>Poppins</family>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="autoFillBackground">
+          <bool>false</bool>
+         </property>
+         <property name="maxLength">
+          <number>15</number>
          </property>
         </widget>
        </widget>
@@ -734,7 +792,16 @@ background-color: #DCE5FE
              </size>
             </property>
             <property name="styleSheet">
-             <string notr="true"/>
+             <string notr="true">QLineEdit{
+background-color: rgb(255, 255, 255);
+border-radius: 5px;
+border: 1px solid black;
+font-family: Poppins;
+}
+
+QDateEdit{
+background-color: rgb(255, 255, 255);
+}</string>
             </property>
             <property name="frameShape">
              <enum>QFrame::StyledPanel</enum>
@@ -742,349 +809,11 @@ background-color: #DCE5FE
             <property name="frameShadow">
              <enum>QFrame::Raised</enum>
             </property>
-            <widget class="QFrame" name="groupExp1">
-             <property name="geometry">
-              <rect>
-               <x>6</x>
-               <y>20</y>
-               <width>500</width>
-               <height>171</height>
-              </rect>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">QFrame{
-background-color: rgba(231, 226, 226, 0.66);
-border: 1px solid black;
-}
-
-QLabel{
-border: none;
-}
-</string>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::StyledPanel</enum>
-             </property>
-             <property name="frameShadow">
-              <enum>QFrame::Raised</enum>
-             </property>
-             <layout class="QGridLayout" name="gridLayout">
-              <item row="0" column="0">
-               <widget class="QLabel" name="dateLabel_4">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Date</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="fromLabel_4">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>From</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QDateEdit" name="dateStart_4">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true"/>
-                </property>
-                <property name="displayFormat">
-                 <string>MM/dd/yyyy</string>
-                </property>
-                <property name="calendarPopup">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="QLabel" name="toLabel_4">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>To</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="4">
-               <widget class="QDateEdit" name="dateEnd_4">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="displayFormat">
-                 <string>MM/dd/yyyy</string>
-                </property>
-                <property name="calendarPopup">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="companyLabel_4">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Company</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2" colspan="3">
-               <widget class="QPlainTextEdit" name="companyTextEdit_4">
-                <property name="styleSheet">
-                 <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="addressLabel_4">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Address</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2" colspan="3">
-               <widget class="QPlainTextEdit" name="addressTextEdit_4">
-                <property name="styleSheet">
-                 <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="positionLabel_4">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="2" colspan="3">
-               <widget class="QPlainTextEdit" name="positionTextEdit_4">
-                <property name="styleSheet">
-                 <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QFrame" name="groupExp1_2">
-             <property name="geometry">
-              <rect>
-               <x>6</x>
-               <y>200</y>
-               <width>500</width>
-               <height>171</height>
-              </rect>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">QFrame{
-background-color: rgba(231, 226, 226, 0.66);
-border: 1px solid black;
-}
-
-QLabel{
-border: none;
-}
-</string>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::StyledPanel</enum>
-             </property>
-             <property name="frameShadow">
-              <enum>QFrame::Raised</enum>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_2">
-              <item row="0" column="0">
-               <widget class="QLabel" name="dateLabel_6">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Date</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="fromLabel_6">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>From</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QDateEdit" name="dateStart_6">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true"/>
-                </property>
-                <property name="displayFormat">
-                 <string>MM/dd/yyyy</string>
-                </property>
-                <property name="calendarPopup">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="QLabel" name="toLabel_6">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>To</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="4">
-               <widget class="QDateEdit" name="dateEnd_6">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="displayFormat">
-                 <string>MM/dd/yyyy</string>
-                </property>
-                <property name="calendarPopup">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="companyLabel_6">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Company</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2" colspan="3">
-               <widget class="QPlainTextEdit" name="companyTextEdit_6">
-                <property name="styleSheet">
-                 <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="addressLabel_6">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Address</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2" colspan="3">
-               <widget class="QPlainTextEdit" name="addressTextEdit_6">
-                <property name="styleSheet">
-                 <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="positionLabel_6">
-                <property name="font">
-                 <font>
-                  <family>Poppins</family>
-                  <pointsize>13</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="2" colspan="3">
-               <widget class="QPlainTextEdit" name="positionTextEdit_6">
-                <property name="styleSheet">
-                 <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
             <widget class="QFrame" name="groupExp1_3">
              <property name="geometry">
               <rect>
-               <x>6</x>
-               <y>380</y>
+               <x>7</x>
+               <y>363</y>
                <width>500</width>
                <height>171</height>
               </rect>
@@ -1142,7 +871,7 @@ border: none;
                  </font>
                 </property>
                 <property name="styleSheet">
-                 <string notr="true"/>
+                 <string notr="true">background-color: rgb(255, 255, 255);</string>
                 </property>
                 <property name="displayFormat">
                  <string>MM/dd/yyyy</string>
@@ -1163,6 +892,9 @@ border: none;
                 <property name="text">
                  <string>To</string>
                 </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
                </widget>
               </item>
               <item row="0" column="4">
@@ -1172,6 +904,9 @@ border: none;
                   <family>Poppins</family>
                   <pointsize>13</pointsize>
                  </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">background-color: rgb(255, 255, 255);</string>
                 </property>
                 <property name="displayFormat">
                  <string>MM/dd/yyyy</string>
@@ -1194,15 +929,6 @@ border: none;
                 </property>
                </widget>
               </item>
-              <item row="1" column="2" colspan="3">
-               <widget class="QPlainTextEdit" name="companyTextEdit_5">
-                <property name="styleSheet">
-                 <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-                </property>
-               </widget>
-              </item>
               <item row="2" column="0">
                <widget class="QLabel" name="addressLabel_5">
                 <property name="font">
@@ -1213,15 +939,6 @@ border: 1px solid black;</string>
                 </property>
                 <property name="text">
                  <string>Address</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2" colspan="3">
-               <widget class="QPlainTextEdit" name="addressTextEdit_5">
-                <property name="styleSheet">
-                 <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
                 </property>
                </widget>
               </item>
@@ -1238,12 +955,417 @@ border: 1px solid black;</string>
                 </property>
                </widget>
               </item>
+              <item row="1" column="2" colspan="3">
+               <widget class="QLineEdit" name="companyTextEdit_5">
+                <property name="minimumSize">
+                 <size>
+                  <width>312</width>
+                  <height>33</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2" colspan="3">
+               <widget class="QLineEdit" name="addressTextEdit_5">
+                <property name="minimumSize">
+                 <size>
+                  <width>312</width>
+                  <height>33</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
               <item row="3" column="2" colspan="3">
-               <widget class="QPlainTextEdit" name="positionTextEdit_5">
+               <widget class="QLineEdit" name="positionTextEdit_5">
+                <property name="minimumSize">
+                 <size>
+                  <width>312</width>
+                  <height>33</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QFrame" name="groupExp1_2">
+             <property name="geometry">
+              <rect>
+               <x>7</x>
+               <y>183</y>
+               <width>500</width>
+               <height>171</height>
+              </rect>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">QFrame{
+background-color: rgba(231, 226, 226, 0.66);
+border: 1px solid black;
+}
+
+QLabel{
+border: none;
+}
+</string>
+             </property>
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_2">
+              <item row="0" column="1">
+               <widget class="QLabel" name="fromLabel_6">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>From</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2" colspan="3">
+               <widget class="QLineEdit" name="companyTextEdit_6">
+                <property name="minimumSize">
+                 <size>
+                  <width>312</width>
+                  <height>33</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="dateLabel_6">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Date</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="positionLabel_6">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Position</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="addressLabel_6">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Address</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2" colspan="3">
+               <widget class="QLineEdit" name="addressTextEdit_6">
+                <property name="minimumSize">
+                 <size>
+                  <width>312</width>
+                  <height>33</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QDateEdit" name="dateStart_6">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">background-color: rgb(255, 255, 255);</string>
+                </property>
+                <property name="displayFormat">
+                 <string>MM/dd/yyyy</string>
+                </property>
+                <property name="calendarPopup">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="QLabel" name="toLabel_6">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>To</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="companyLabel_6">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Company</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="4">
+               <widget class="QDateEdit" name="dateEnd_6">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">background-color: rgb(255, 255, 255);</string>
+                </property>
+                <property name="displayFormat">
+                 <string>MM/dd/yyyy</string>
+                </property>
+                <property name="calendarPopup">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2" colspan="3">
+               <widget class="QLineEdit" name="positionTextEdit_6">
+                <property name="minimumSize">
+                 <size>
+                  <width>312</width>
+                  <height>33</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QFrame" name="groupExp1">
+             <property name="geometry">
+              <rect>
+               <x>7</x>
+               <y>3</y>
+               <width>500</width>
+               <height>171</height>
+              </rect>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">QFrame{
+background-color: rgba(231, 226, 226, 0.66);
+border: 1px solid black;
+}
+
+QLabel{
+border: none;
+}
+</string>
+             </property>
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Raised</enum>
+             </property>
+             <layout class="QGridLayout" name="gridLayout">
+              <item row="0" column="2">
+               <widget class="QDateEdit" name="dateStart_4">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
                 <property name="styleSheet">
                  <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
+color: black;</string>
+                </property>
+                <property name="displayFormat">
+                 <string>MM/dd/yyyy</string>
+                </property>
+                <property name="calendarPopup">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="positionLabel_4">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Position</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="addressLabel_4">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Address</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="fromLabel_4">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>From</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="4">
+               <widget class="QDateEdit" name="dateEnd_4">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">background-color: rgb(255, 255, 255);</string>
+                </property>
+                <property name="displayFormat">
+                 <string>MM/dd/yyyy</string>
+                </property>
+                <property name="calendarPopup">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2" colspan="3">
+               <widget class="QLineEdit" name="companyTextEdit_4">
+                <property name="minimumSize">
+                 <size>
+                  <width>312</width>
+                  <height>33</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="QLabel" name="toLabel_4">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>To</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="companyLabel_4">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Company</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="dateLabel_4">
+                <property name="font">
+                 <font>
+                  <family>Poppins</family>
+                  <pointsize>13</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Date</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2" colspan="3">
+               <widget class="QLineEdit" name="addressTextEdit_4">
+                <property name="minimumSize">
+                 <size>
+                  <width>312</width>
+                  <height>33</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="2" colspan="3">
+               <widget class="QLineEdit" name="positionTextEdit_4">
+                <property name="minimumSize">
+                 <size>
+                  <width>312</width>
+                  <height>33</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -1289,6 +1411,13 @@ border: 1px solid black;
 
 QLabel{
 border: none;
+}
+
+QLineEdit{
+background-color: rgb(255, 255, 255);
+border-radius: 5px;
+border: 1px solid black;
+font-family: Poppins;
 }</string>
         </property>
         <property name="frameShape">
@@ -1301,10 +1430,13 @@ border: none;
          <property name="geometry">
           <rect>
            <x>0</x>
-           <y>10</y>
+           <y>20</y>
            <width>770</width>
            <height>131</height>
           </rect>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">font-family: Poppins;</string>
          </property>
          <widget class="QLabel" name="validationLabel">
           <property name="geometry">
@@ -1348,33 +1480,6 @@ border: none;
           </property>
           <property name="calendarPopup">
            <bool>true</bool>
-          </property>
-         </widget>
-         <widget class="QPlainTextEdit" name="certiTextEdit1_3">
-          <property name="geometry">
-           <rect>
-            <x>336</x>
-            <y>90</y>
-            <width>271</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
           </property>
          </widget>
          <widget class="QDateEdit" name="validationDate1_2">
@@ -1421,87 +1526,6 @@ border: 1px solid black;</string>
            <string>Certification</string>
           </property>
          </widget>
-         <widget class="QPlainTextEdit" name="techSkillTextEdit_2">
-          <property name="geometry">
-           <rect>
-            <x>9</x>
-            <y>60</y>
-            <width>321</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-         </widget>
-         <widget class="QPlainTextEdit" name="certiTextEdit1_2">
-          <property name="geometry">
-           <rect>
-            <x>336</x>
-            <y>60</y>
-            <width>271</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-         </widget>
-         <widget class="QPlainTextEdit" name="certiTextEdit1">
-          <property name="geometry">
-           <rect>
-            <x>336</x>
-            <y>30</y>
-            <width>271</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-         </widget>
          <widget class="QLabel" name="techSkillLabel">
           <property name="geometry">
            <rect>
@@ -1519,33 +1543,6 @@ border: 1px solid black;</string>
           </property>
           <property name="text">
            <string> Technical Skills</string>
-          </property>
-         </widget>
-         <widget class="QPlainTextEdit" name="techSkillTextEdit">
-          <property name="geometry">
-           <rect>
-            <x>9</x>
-            <y>30</y>
-            <width>321</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
           </property>
          </widget>
          <widget class="QDateEdit" name="validationDate1_3">
@@ -1573,31 +1570,67 @@ border: 1px solid black;</string>
            <bool>true</bool>
           </property>
          </widget>
-         <widget class="QPlainTextEdit" name="techSkillTextEdit_3">
+         <widget class="QLineEdit" name="techSkillTextEdit">
           <property name="geometry">
            <rect>
-            <x>9</x>
+            <x>10</x>
+            <y>30</y>
+            <width>321</width>
+            <height>27</height>
+           </rect>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+         <widget class="QLineEdit" name="techSkillTextEdit_2">
+          <property name="geometry">
+           <rect>
+            <x>10</x>
+            <y>60</y>
+            <width>321</width>
+            <height>27</height>
+           </rect>
+          </property>
+         </widget>
+         <widget class="QLineEdit" name="techSkillTextEdit_3">
+          <property name="geometry">
+           <rect>
+            <x>10</x>
             <y>90</y>
             <width>321</width>
             <height>27</height>
            </rect>
           </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
+         </widget>
+         <widget class="QLineEdit" name="certiTextEdit1">
+          <property name="geometry">
+           <rect>
+            <x>336</x>
+            <y>30</y>
+            <width>271</width>
+            <height>27</height>
+           </rect>
           </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
+         </widget>
+         <widget class="QLineEdit" name="certiTextEdit1_2">
+          <property name="geometry">
+           <rect>
+            <x>336</x>
+            <y>60</y>
+            <width>271</width>
+            <height>27</height>
+           </rect>
           </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
+         </widget>
+         <widget class="QLineEdit" name="certiTextEdit1_3">
+          <property name="geometry">
+           <rect>
+            <x>336</x>
+            <y>90</y>
+            <width>271</width>
+            <height>27</height>
+           </rect>
           </property>
          </widget>
         </widget>
@@ -1605,10 +1638,13 @@ border: 1px solid black;</string>
          <property name="geometry">
           <rect>
            <x>0</x>
-           <y>160</y>
+           <y>170</y>
            <width>770</width>
            <height>131</height>
           </rect>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">font-family: Poppins;</string>
          </property>
          <widget class="QLabel" name="schoolYear_2">
           <property name="geometry">
@@ -1652,33 +1688,6 @@ border: 1px solid black;</string>
           </property>
           <property name="calendarPopup">
            <bool>true</bool>
-          </property>
-         </widget>
-         <widget class="QPlainTextEdit" name="addressTextEdit3">
-          <property name="geometry">
-           <rect>
-            <x>186</x>
-            <y>90</y>
-            <width>291</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
           </property>
          </widget>
          <widget class="QDateEdit" name="schoolYear2">
@@ -1725,90 +1734,6 @@ border: 1px solid black;</string>
            <string>Address</string>
           </property>
          </widget>
-         <widget class="QPlainTextEdit" name="highTextEdit">
-          <property name="geometry">
-           <rect>
-            <x>9</x>
-            <y>60</y>
-            <width>171</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="placeholderText">
-           <string>High-School</string>
-          </property>
-         </widget>
-         <widget class="QPlainTextEdit" name="addressTextEdit2">
-          <property name="geometry">
-           <rect>
-            <x>186</x>
-            <y>60</y>
-            <width>291</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-         </widget>
-         <widget class="QPlainTextEdit" name="addressTextEdit">
-          <property name="geometry">
-           <rect>
-            <x>186</x>
-            <y>30</y>
-            <width>291</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-         </widget>
          <widget class="QLabel" name="schoolLabel">
           <property name="geometry">
            <rect>
@@ -1853,65 +1778,6 @@ border: 1px solid black;</string>
            <bool>true</bool>
           </property>
          </widget>
-         <widget class="QPlainTextEdit" name="elemTextEdit">
-          <property name="geometry">
-           <rect>
-            <x>9</x>
-            <y>90</y>
-            <width>171</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-            <weight>50</weight>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="placeholderText">
-           <string>Elementary</string>
-          </property>
-         </widget>
-         <widget class="QPlainTextEdit" name="courseTextEdit">
-          <property name="geometry">
-           <rect>
-            <x>480</x>
-            <y>30</y>
-            <width>131</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="placeholderText">
-           <string>College Course</string>
-          </property>
-         </widget>
          <widget class="QPlainTextEdit" name="courseTextEdit3">
           <property name="geometry">
            <rect>
@@ -1939,33 +1805,6 @@ border: 1px solid black;</string>
            <bool>true</bool>
           </property>
          </widget>
-         <widget class="QPlainTextEdit" name="courseTextEdit2">
-          <property name="geometry">
-           <rect>
-            <x>480</x>
-            <y>60</y>
-            <width>131</width>
-            <height>27</height>
-           </rect>
-          </property>
-          <property name="font">
-           <font>
-            <family>Poppins</family>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="placeholderText">
-           <string>High-School Strand</string>
-          </property>
-         </widget>
          <widget class="QLabel" name="courseLabel">
           <property name="geometry">
            <rect>
@@ -1985,10 +1824,10 @@ border: 1px solid black;</string>
            <string>Course</string>
           </property>
          </widget>
-         <widget class="QPlainTextEdit" name="collegeTextEdit">
+         <widget class="QLineEdit" name="collegeTextEdit">
           <property name="geometry">
            <rect>
-            <x>9</x>
+            <x>10</x>
             <y>30</y>
             <width>171</width>
             <height>27</height>
@@ -2000,37 +1839,186 @@ border: 1px solid black;</string>
             <pointsize>10</pointsize>
            </font>
           </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
-          </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
+          <property name="text">
+           <string/>
           </property>
           <property name="placeholderText">
            <string>College</string>
           </property>
          </widget>
+         <widget class="QLineEdit" name="highTextEdit">
+          <property name="geometry">
+           <rect>
+            <x>10</x>
+            <y>60</y>
+            <width>171</width>
+            <height>27</height>
+           </rect>
+          </property>
+          <property name="font">
+           <font>
+            <family>Poppins</family>
+            <pointsize>10</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="placeholderText">
+           <string>High-School</string>
+          </property>
+         </widget>
+         <widget class="QLineEdit" name="elemTextEdit">
+          <property name="geometry">
+           <rect>
+            <x>10</x>
+            <y>90</y>
+            <width>171</width>
+            <height>27</height>
+           </rect>
+          </property>
+          <property name="font">
+           <font>
+            <family>Poppins</family>
+            <pointsize>10</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="placeholderText">
+           <string>Elementary</string>
+          </property>
+         </widget>
+         <widget class="QLineEdit" name="addressTextEdit">
+          <property name="geometry">
+           <rect>
+            <x>186</x>
+            <y>30</y>
+            <width>291</width>
+            <height>27</height>
+           </rect>
+          </property>
+          <property name="font">
+           <font>
+            <family>Poppins</family>
+            <pointsize>10</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="placeholderText">
+           <string/>
+          </property>
+         </widget>
+         <widget class="QLineEdit" name="addressTextEdit2">
+          <property name="geometry">
+           <rect>
+            <x>186</x>
+            <y>60</y>
+            <width>291</width>
+            <height>27</height>
+           </rect>
+          </property>
+          <property name="font">
+           <font>
+            <family>Poppins</family>
+            <pointsize>10</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="placeholderText">
+           <string/>
+          </property>
+         </widget>
+         <widget class="QLineEdit" name="addressTextEdit3">
+          <property name="geometry">
+           <rect>
+            <x>186</x>
+            <y>90</y>
+            <width>291</width>
+            <height>27</height>
+           </rect>
+          </property>
+          <property name="font">
+           <font>
+            <family>Poppins</family>
+            <pointsize>10</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="readOnly">
+           <bool>false</bool>
+          </property>
+          <property name="placeholderText">
+           <string/>
+          </property>
+         </widget>
+         <widget class="QLineEdit" name="courseTextEdit">
+          <property name="geometry">
+           <rect>
+            <x>480</x>
+            <y>30</y>
+            <width>131</width>
+            <height>27</height>
+           </rect>
+          </property>
+          <property name="font">
+           <font>
+            <family>Poppins</family>
+            <pointsize>10</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="placeholderText">
+           <string>College Course</string>
+          </property>
+         </widget>
+         <widget class="QLineEdit" name="courseTextEdit2">
+          <property name="geometry">
+           <rect>
+            <x>480</x>
+            <y>60</y>
+            <width>131</width>
+            <height>27</height>
+           </rect>
+          </property>
+          <property name="font">
+           <font>
+            <family>Poppins</family>
+            <pointsize>10</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="placeholderText">
+           <string>HS Strand</string>
+          </property>
+         </widget>
          <zorder>courseLabel</zorder>
          <zorder>schoolYear_2</zorder>
          <zorder>schoolYear</zorder>
-         <zorder>addressTextEdit3</zorder>
          <zorder>schoolYear2</zorder>
          <zorder>addressLabel</zorder>
-         <zorder>highTextEdit</zorder>
-         <zorder>addressTextEdit2</zorder>
-         <zorder>addressTextEdit</zorder>
          <zorder>schoolLabel</zorder>
          <zorder>schoolYear3</zorder>
-         <zorder>elemTextEdit</zorder>
-         <zorder>courseTextEdit</zorder>
          <zorder>courseTextEdit3</zorder>
-         <zorder>courseTextEdit2</zorder>
          <zorder>collegeTextEdit</zorder>
+         <zorder>highTextEdit</zorder>
+         <zorder>elemTextEdit</zorder>
+         <zorder>addressTextEdit</zorder>
+         <zorder>addressTextEdit2</zorder>
+         <zorder>addressTextEdit3</zorder>
+         <zorder>courseTextEdit</zorder>
+         <zorder>courseTextEdit2</zorder>
         </widget>
        </widget>
        <widget class="QLabel" name="educInfoLabel">
@@ -3445,7 +3433,13 @@ border-radius: 4px;
 border: 1px solid black;
 font-family: Poppins;
 }
-</string>
+
+QLineEdit{
+background-color: rgb(255, 255, 255);
+border-radius: 5px;
+border: 1px solid black;
+font-family: Poppins;
+}</string>
         </property>
         <property name="frameShape">
          <enum>QFrame::StyledPanel</enum>
@@ -3593,30 +3587,6 @@ font-family: Poppins;
           </property>
          </item>
         </widget>
-        <widget class="QPlainTextEdit" name="posTextEdit">
-         <property name="geometry">
-          <rect>
-           <x>6</x>
-           <y>190</y>
-           <width>220</width>
-           <height>31</height>
-          </rect>
-         </property>
-         <property name="font">
-          <font>
-           <family>Poppins</family>
-           <pointsize>10</pointsize>
-          </font>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-         </property>
-         <property name="verticalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
-         </property>
-        </widget>
         <widget class="QLabel" name="posLabel">
          <property name="geometry">
           <rect>
@@ -3636,34 +3606,10 @@ border: 1px solid black;</string>
           <string>Position/s</string>
          </property>
         </widget>
-        <widget class="QPlainTextEdit" name="posTextEdit_2">
-         <property name="geometry">
-          <rect>
-           <x>7</x>
-           <y>260</y>
-           <width>220</width>
-           <height>31</height>
-          </rect>
-         </property>
-         <property name="font">
-          <font>
-           <family>Poppins</family>
-           <pointsize>10</pointsize>
-          </font>
-         </property>
-         <property name="styleSheet">
-          <string notr="true">background-color: rgb(255, 255, 255);
-border-radius: 5px;
-border: 1px solid black;</string>
-         </property>
-         <property name="verticalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
-         </property>
-        </widget>
         <widget class="QLabel" name="groupLabel">
          <property name="geometry">
           <rect>
-           <x>10</x>
+           <x>8</x>
            <y>232</y>
            <width>211</width>
            <height>31</height>
@@ -3677,6 +3623,50 @@ border: 1px solid black;</string>
          </property>
          <property name="text">
           <string>Group/s</string>
+         </property>
+        </widget>
+        <widget class="QLineEdit" name="groupTextEdit">
+         <property name="geometry">
+          <rect>
+           <x>8</x>
+           <y>255</y>
+           <width>220</width>
+           <height>31</height>
+          </rect>
+         </property>
+         <property name="font">
+          <font>
+           <family>Poppins</family>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="autoFillBackground">
+          <bool>false</bool>
+         </property>
+         <property name="maxLength">
+          <number>15</number>
+         </property>
+        </widget>
+        <widget class="QLineEdit" name="posTextEdit">
+         <property name="geometry">
+          <rect>
+           <x>7</x>
+           <y>190</y>
+           <width>220</width>
+           <height>31</height>
+          </rect>
+         </property>
+         <property name="font">
+          <font>
+           <family>Poppins</family>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="autoFillBackground">
+          <bool>false</bool>
+         </property>
+         <property name="maxLength">
+          <number>15</number>
          </property>
         </widget>
        </widget>

--- a/FILE201/file201_Function/listFunction.py
+++ b/FILE201/file201_Function/listFunction.py
@@ -169,8 +169,8 @@ class ListFunction:
              college_add, highschool_add, elem_add, college_course, highschool_strand, college_year,
              highschool_year, elem_year) = data
 
-            modal.lblTitle_2.setText(f"Name: {lastName} {firstName} {middleName}")
-            modal.lblTitle_3.setText(str(empID))
+            modal.nameDisplay.setText(f"{lastName} {firstName} {middleName}")
+            modal.idDisplay.setText(str(empID))
             modal.txtLastName.setText(lastName)
             modal.txtFirstName.setText(firstName)
             modal.txtMiddleName.setText(middleName)
@@ -201,39 +201,39 @@ class ListFunction:
             modal.txtBeneMiddle.setText(beneficiaryMiddleName)
             modal.txtDependent.setText(dependentsName)
 
-            modal.sssTextEdit.setPlainText(sss_num)
-            modal.pagibigTextEdit.setPlainText(pagibig_num)
-            modal.philHealthTextEdit.setPlainText(philhealth_num)
-            modal.tinTextEdit.setPlainText(tin_num)
+            modal.sssTextEdit.setText(sss_num)
+            modal.pagibigTextEdit.setText(pagibig_num)
+            modal.philHealthTextEdit.setText(philhealth_num)
+            modal.tinTextEdit.setText(tin_num)
 
             modal.dateStart_4.setDate(QDate.fromString(from_date, "MM-dd-yyyy"))
             modal.dateEnd_4.setDate(QDate.fromString(to_date, "MM-dd-yyyy"))
-            modal.companyTextEdit_4.setPlainText(company_name)
-            modal.addressTextEdit_4.setPlainText(company_add)
-            modal.positionTextEdit_4.setPlainText(position)
+            modal.companyTextEdit_4.setText(company_name)
+            modal.addressTextEdit_4.setText(company_add)
+            modal.positionTextEdit_4.setText(position)
 
-            modal.techSkillTextEdit.setPlainText(tech_skill1)
-            modal.certiTextEdit1.setPlainText(certificate_skill1)
+            modal.techSkillTextEdit.setText(tech_skill1)
+            modal.certiTextEdit1.setText(certificate_skill1)
             modal.validationDate1.setDate(QDate.fromString(validation_date1, "MM-dd-yyyy"))
 
-            modal.techSkillTextEdit_2.setPlainText(tech_skill2)
-            modal.certiTextEdit1_2.setPlainText(certificate_skill2)
+            modal.techSkillTextEdit_2.setText(tech_skill2)
+            modal.certiTextEdit1_2.setText(certificate_skill2)
             modal.validationDate1_2.setDate(QDate.fromString(validation_date2, "MM-dd-yyyy"))
 
-            modal.techSkillTextEdit_3.setPlainText(tech_skill3)
-            modal.certiTextEdit1_3.setPlainText(certificate_skill3)
+            modal.techSkillTextEdit_3.setText(tech_skill3)
+            modal.certiTextEdit1_3.setText(certificate_skill3)
             modal.validationDate1_3.setDate(QDate.fromString(validation_date3, "MM-dd-yyyy"))
 
-            modal.collegeTextEdit.setPlainText(college)
-            modal.highTextEdit.setPlainText(high_school)
-            modal.elemTextEdit.setPlainText(elem_school)
+            modal.collegeTextEdit.setText(college)
+            modal.highTextEdit.setText(high_school)
+            modal.elemTextEdit.setText(elem_school)
 
-            modal.addressTextEdit.setPlainText(college_add)
-            modal.addressTextEdit2.setPlainText(highschool_add)
-            modal.addressTextEdit3.setPlainText(elem_add)
+            modal.addressTextEdit.setText(college_add)
+            modal.addressTextEdit2.setText(highschool_add)
+            modal.addressTextEdit3.setText(elem_add)
 
-            modal.courseTextEdit.setPlainText(college_course)
-            modal.courseTextEdit2.setPlainText(highschool_strand)
+            modal.courseTextEdit.setText(college_course)
+            modal.courseTextEdit2.setText(highschool_strand)
 
             modal.schoolYear.setDate(QDate.fromString(college_year, "MM-dd-yyyy"))
             modal.schoolYear2.setDate(QDate.fromString(highschool_year, "MM-dd-yyyy"))

--- a/FILE201/file201_Function/modalFunction.py
+++ b/FILE201/file201_Function/modalFunction.py
@@ -79,10 +79,10 @@ class modalFunction:
                 ("Dependent's Name", self.main_window.txtDependent.text()),
 
                 # Employee ID inputs
-                ('SSS Number', self.main_window.sssTextEdit.toPlainText()),
-                ('Pag-IBIG Number', self.main_window.pagibigTextEdit.toPlainText()),
-                ('PhilHealth Number', self.main_window.philHealthTextEdit.toPlainText()),
-                ('TIN Number', self.main_window.tinTextEdit.toPlainText()),
+                ('SSS Number', self.main_window.sssTextEdit.text()),
+                ('Pag-IBIG Number', self.main_window.pagibigTextEdit.text()),
+                ('PhilHealth Number', self.main_window.philHealthTextEdit.text()),
+                ('TIN Number', self.main_window.tinTextEdit.text()),
 
                 # HR Notes Text Input
                 ('HR Notes', self.main_window.hrNoteTextEdit.toPlainText()),
@@ -90,33 +90,33 @@ class modalFunction:
                 # Working Experience Containers/Inputs
                 ('Date From', self.main_window.dateStart_4.date().toString("MM-dd-yyyy")),
                 ('Date To', self.main_window.dateEnd_4.date().toString("MM-dd-yyyy")),
-                ('Company', self.main_window.companyTextEdit_4.toPlainText()),
-                ('Company Address', self.main_window.addressTextEdit_4.toPlainText()),
-                ('Position', self.main_window.positionTextEdit_4.toPlainText()),
+                ('Company', self.main_window.companyTextEdit_4.text()),
+                ('Company Address', self.main_window.addressTextEdit_4.text()),
+                ('Position', self.main_window.positionTextEdit_4.text()),
 
                 # Educational and Skill Information text and date inputs
-                ('Technical Skills #1', self.main_window.techSkillTextEdit.toPlainText()),
-                ('Technical Skills #2', self.main_window.techSkillTextEdit_2.toPlainText()),
-                ('Technical Skills #3', self.main_window.techSkillTextEdit_3.toPlainText()),
+                ('Technical Skills #1', self.main_window.techSkillTextEdit.text()),
+                ('Technical Skills #2', self.main_window.techSkillTextEdit_2.text()),
+                ('Technical Skills #3', self.main_window.techSkillTextEdit_3.text()),
 
-                ('Certificate #1', self.main_window.certiTextEdit1.toPlainText()),
-                ('Certificate #2', self.main_window.certiTextEdit1_2.toPlainText()),
-                ('Certificate #3', self.main_window.certiTextEdit1_3.toPlainText()),
+                ('Certificate #1', self.main_window.certiTextEdit1.text()),
+                ('Certificate #2', self.main_window.certiTextEdit1_2.text()),
+                ('Certificate #3', self.main_window.certiTextEdit1_3.text()),
 
                 ('Validation Date #1', self.main_window.validationDate1.date().toString("MM-dd-yyyy")),
                 ('Validation Date #2', self.main_window.validationDate1_2.date().toString("MM.dd.yyyy")),
                 ('Validation Date #3', self.main_window.validationDate1_3.date().toString("MM.dd.yyyy")),
 
-                ('College', self.main_window.collegeTextEdit.toPlainText()),
-                ('High-School', self.main_window.highTextEdit.toPlainText()),
-                ('Elementary', self.main_window.elemTextEdit.toPlainText()),
+                ('College', self.main_window.collegeTextEdit.text()),
+                ('High-School', self.main_window.highTextEdit.text()),
+                ('Elementary', self.main_window.elemTextEdit.text()),
 
-                ('College Address', self.main_window.addressTextEdit.toPlainText()),
-                ('High-School Address', self.main_window.addressTextEdit2.toPlainText()),
-                ('Elementary Address', self.main_window.addressTextEdit3.toPlainText()),
+                ('College Address', self.main_window.addressTextEdit.text()),
+                ('High-School Address', self.main_window.addressTextEdit2.text()),
+                ('Elementary Address', self.main_window.addressTextEdit3.text()),
 
-                ('College Course', self.main_window.courseTextEdit.toPlainText()),
-                ('High-School Strand', self.main_window.courseTextEdit2.toPlainText()),
+                ('College Course', self.main_window.courseTextEdit.text()),
+                ('High-School Strand', self.main_window.courseTextEdit2.text()),
 
                 ('College Graduate Year', self.main_window.schoolYear.date().toString("MM-dd-yyyy")),
                 ('High-School Graduate Year', self.main_window.schoolYear2.date().toString("MM-dd-yyyy")),

--- a/TimeKeeping/timeLogger/timeLog.ui
+++ b/TimeKeeping/timeLogger/timeLog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1160</width>
+    <width>1180</width>
     <height>665</height>
    </rect>
   </property>


### PR DESCRIPTION
By using a library fro m PyQT5 called QIntValidator I write the code easier for taking only integers in the following inputs.

        self.txtZip.setValidator(int_validator)
        self.txtPhone.setValidator(int_validator)
        self.txtHeight.setValidator(int_validator)
        self.txtWeight.setValidator(int_validator)
        self.sssTextEdit.setValidator(int_validator)
        self.pagibigTextEdit.setValidator(int_validator)
        self.philHealthTextEdit.setValidator(int_validator)
        self.tinTextEdit.setValidator(int_validator)

All input are now QLineEdit instead of QPlainTextEdit.

Adjust some code for taking input (importing into database) and Displaying (From Database int UI)

Added a function where when "ESC Button" from keyboard clicked the Modal closes.
       
        