### PR TITLE
CHANGING UI's

### DIFF
--- a/MainFrame/FILE201/Other_Information/otherInformationModal.py
+++ b/MainFrame/FILE201/Other_Information/otherInformationModal.py
@@ -8,7 +8,7 @@ from MainFrame.FILE201.file201_Function.modalFunction import modalFunction
 from MainFrame.systemFunctions import globalFunction
 
 class personalModal(QDialog):
-    def __init__(self):
+    def __init__(self, mode='view'):
         super(personalModal, self).__init__()
         self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
         self.setFixedSize(1153, 665)
@@ -17,18 +17,109 @@ class personalModal(QDialog):
         loadUi(ui_file, self)
 
         self.functions = modalFunction(self)
+        self.mode = mode
 
         current_date = QtCore.QDate.currentDate()
         self.set_current_date_to_all_date_edits(current_date)
 
+        self.editBTN.setText("Edit")
+
+        self.setup_initial_state()
+        self.install_event_filters()
+
         self.addBTN.clicked.connect(self.functions.add_Employee)
-        self.editBTN.clicked.connect(self.functions.edit_Employee)
-        self.editBTN.clicked.connect(self.enable_save_button)
+        self.editBTN.clicked.connect(self.on_edit_clicked)
         self.saveBTN.clicked.connect(self.functions.save_Employee)
         self.revertBTN.clicked.connect(self.functions.revert_Employee)
 
         self.set_validators()
         self.set_keyboard_shortcut()
+
+    def setup_initial_state(self):
+        if self.mode == 'view':
+            self.addBTN.setVisible(False)
+            self.editBTN.setEnabled(True)
+            self.saveBTN.setEnabled(False)
+            self.revertBTN.setEnabled(False)
+        elif self.mode == 'add':
+            self.addBTN.setVisible(True)
+            self.editBTN.setVisible(False)
+            self.saveBTN.setEnabled(False)
+            self.revertBTN.setEnabled(False)
+
+        self.set_button_styles()
+
+    def install_event_filters(self):
+        self.addBTN.installEventFilter(self)
+        self.editBTN.installEventFilter(self)
+        self.saveBTN.installEventFilter(self)
+        self.revertBTN.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Enter:
+            if not obj.isEnabled():
+                QApplication.setOverrideCursor(Qt.ForbiddenCursor)
+            return True
+        elif event.type() == QEvent.Leave:
+            QApplication.restoreOverrideCursor()
+            return True
+        return super().eventFilter(obj, event)
+
+    def on_edit_clicked(self):
+        if self.editBTN.text() == "Edit":
+            self.functions.edit_Employee()
+            self.editBTN.setText("Cancel")
+            self.saveBTN.setEnabled(True)
+            self.revertBTN.setEnabled(True)
+            self.set_button_styles()
+        else:
+            self.cancel_edit()
+
+    def set_button_styles(self):
+        enabled_style = "background-color:  rgba(52, 66, 115, 1); color: white;"
+        disabled_style = "background-color: #cccccc; color: #666666;"
+
+        self.addBTN.setStyleSheet(enabled_style if self.mode == 'add' else disabled_style)
+        self.editBTN.setStyleSheet(enabled_style if self.mode == 'view' else disabled_style)
+
+        if self.editBTN.text() == "Cancel":
+            self.editBTN.setStyleSheet("background-color: #a12c23; color: white;")
+            self.saveBTN.setStyleSheet(enabled_style)
+            self.revertBTN.setStyleSheet(enabled_style)
+            self.saveBTN.setEnabled(True)
+            self.revertBTN.setEnabled(True)
+        else:
+            self.saveBTN.setStyleSheet(disabled_style)
+            self.revertBTN.setStyleSheet(disabled_style)
+            self.saveBTN.setEnabled(False)
+            self.revertBTN.setEnabled(False)
+
+        self.addBTN.setEnabled(self.mode == 'add')
+        self.editBTN.setEnabled(self.mode == 'view')
+
+    def cancel_edit(self):
+        self.editBTN.setText("Edit")
+        self.set_button_styles()
+        self.set_fields_non_editable()
+
+    def set_fields_non_editable(self):
+        disabledStyle = "background-color: #f0f0f0; color: #4f4e4e;"
+
+        for widget in self.findChildren(QLineEdit):
+            widget.setReadOnly(True)
+            widget.setStyleSheet(disabledStyle)
+
+        for widget in self.findChildren(QDateEdit):
+            widget.setReadOnly(True)
+            widget.setStyleSheet(disabledStyle)
+
+        for widget in self.findChildren(QComboBox):
+            widget.setEnabled(False)
+            widget.setStyleSheet(disabledStyle)
+
+        for widget in self.findChildren(QPlainTextEdit):
+            widget.setReadOnly(True)
+            widget.setStyleSheet(disabledStyle)
 
     def set_current_date_to_all_date_edits(self, current_date):
         for widget in self.findChildren(QtWidgets.QDateEdit):
@@ -49,6 +140,3 @@ class personalModal(QDialog):
     def set_keyboard_shortcut(self):
         self.shortcut = QtWidgets.QShortcut(Qt.Key_Escape, self)
         self.shortcut.activated.connect(self.close)
-
-    def enable_save_button(self):
-        self.saveBTN.setEnabled(True)

--- a/MainFrame/FILE201/file201_Function/listFunction.py
+++ b/MainFrame/FILE201/file201_Function/listFunction.py
@@ -78,9 +78,7 @@ class ListFunction:
                 self.main_window.employeeListTable.setItem(rowNum, column, QTableWidgetItem(str(data)))
 
     def open_otherInformationMODAL_view(self):
-        modal = personalModal()
-        modal.addBTN.setEnabled(False)
-        modal.saveBTN.setEnabled(False)
+        modal = personalModal(mode='view')
 
         selected_row = self.main_window.employeeListTable.currentRow()
         if selected_row != -1:
@@ -254,10 +252,7 @@ class ListFunction:
             print(f"Error: {e}")
 
     def open_otherInformationMODAL_add(self):
-        modal = personalModal()
-        modal.editBTN.setEnabled(False)
-        modal.saveBTN.setEnabled(False)
-        modal.revertBTN.setEnabled(False)
+        modal = personalModal(mode='add')
         modal.finished.connect(self.displayEmployees)  # Updates the employeeListTable upon closing
         modal.exec_()
 

--- a/MainFrame/FILE201/file201_Function/modalFunction.py
+++ b/MainFrame/FILE201/file201_Function/modalFunction.py
@@ -162,7 +162,26 @@ class modalFunction:
             QMessageBox.critical(self.main_window, "Error", f"An error occurred: {e}")
 
     def edit_Employee(self):
-        set_fields_non_editable(self.main_window)
+        self.set_fields_editable()
+
+    def set_fields_editable(self):
+        activeStyle = "background-color: white; color: black;"
+
+        for widget in self.main_window.findChildren(QLineEdit):
+            widget.setReadOnly(False)
+            widget.setStyleSheet(activeStyle)
+
+        for widget in self.main_window.findChildren(QDateEdit):
+            widget.setReadOnly(False)
+            widget.setStyleSheet(activeStyle)
+
+        for widget in self.main_window.findChildren(QComboBox):
+            widget.setEnabled(True)
+            widget.setStyleSheet(activeStyle)
+
+        for widget in self.main_window.findChildren(QPlainTextEdit):
+            widget.setReadOnly(False)
+            widget.setStyleSheet(activeStyle)
 
     def gather_form_data(self):
         data = {
@@ -266,5 +285,5 @@ class modalFunction:
 
 
     def revert_Employee(self):
+        set_fields_non_editable(self.main_window)
         print("Revert")
-

--- a/MainFrame/Resources/UI/datechange.ui
+++ b/MainFrame/Resources/UI/datechange.ui
@@ -69,9 +69,9 @@ font-family: Poppins;</string>
    <property name="geometry">
     <rect>
      <x>90</x>
-     <y>250</y>
+     <y>240</y>
      <width>51</width>
-     <height>21</height>
+     <height>31</height>
     </rect>
    </property>
    <property name="font">

--- a/MainFrame/Resources/lib.py
+++ b/MainFrame/Resources/lib.py
@@ -21,7 +21,7 @@ import smtplib
 from dotenv import load_dotenv
 
 from PyQt5.QtCore import QTimer, QDate, Qt, QEvent, QTime, QObject, pyqtSignal, QThread
-from PyQt5.QtGui import QFont, QFontDatabase, QIntValidator
+from PyQt5.QtGui import QFont, QFontDatabase, QIntValidator, QStandardItemModel
 from PyQt5.QtWidgets import (
     QMainWindow, QApplication, QVBoxLayout, QFileDialog, QMessageBox, QHeaderView,
     QPushButton, QTableWidgetItem, QPlainTextEdit, QComboBox, QDateEdit, QLineEdit,


### PR DESCRIPTION
Modified Date Change:

- Disabled the combobox dropdown when adding a new holiday name.
- Added a cancel button when adding a new holiday and reset the default UI.

Modified CRUD Buttons in PersonalModal:

- Added two parameters in the personalModal - mode='view' and mode='add' - to differentiate between the two main use cases for the modal: viewing an existing employee's information and adding a new employee.
- Disabled the edit button when in ADD MODE, and disabled the add button when in VIEW MODE, making them invisible.
- Added an event filter when hovering over a disabled button (like save), which changes the cursor of the user to a circle with a backslash, indicating that the button is forbidden or not allowed to be clicked.