### PR TITLE
Converting email content into HTML

### DIFF
--- a/MainFrame/Database_Connection/modalSQLQuery.py
+++ b/MainFrame/Database_Connection/modalSQLQuery.py
@@ -260,7 +260,7 @@ def get_generated_employee_id(employee_id):
     year = str_employee_id[:4]
     id_number = str_employee_id[4:]
 
-    current_year = str(2024)
+    current_year = datetime.now().year
 
     # Validate the format of the employee ID
     if len(str_employee_id) < 8:

--- a/MainFrame/Resources/lib.py
+++ b/MainFrame/Resources/lib.py
@@ -19,6 +19,8 @@ from email.message import EmailMessage
 import ssl
 import smtplib
 import warnings
+from css_inline import inline
+from email.utils import formataddr
 
 from dotenv import load_dotenv
 


### PR DESCRIPTION
- Converted the plain body text of an email content into html.
- installed a 3rd party library called css-inline to embed the styling in html.
- fixed the static value of current_year into real-time year for dynamic data 
![image](https://github.com/user-attachments/assets/60dfa2cb-d399-4701-9f13-3ba70a9e8cf4)
