### PR TITLE
Hidden button for payTimeSheetImporter.py

### DIFF
--- a/MainFrame/Resources/UI/dialogImporter.ui
+++ b/MainFrame/Resources/UI/dialogImporter.ui
@@ -35,7 +35,44 @@ background-color: rgb(255, 110, 112);
 }</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
+   <item row="2" column="0">
+    <widget class="QPushButton" name="btnProcessTimeCard">
+     <property name="minimumSize">
+      <size>
+       <width>50</width>
+       <height>80</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <family>Poppins</family>
+       <pointsize>18</pointsize>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>Process Time Card</string>
+     </property>
+     <property name="icon">
+      <iconset>
+       <normaloff>../../MainFrame/Resources/Icons/import.svg</normaloff>../../MainFrame/Resources/Icons/import.svg</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>30</width>
+       <height>30</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
     <widget class="QPushButton" name="importBTN">
      <property name="minimumSize">
       <size>
@@ -74,40 +111,10 @@ background-color: rgb(255, 110, 112);
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QPushButton" name="btnProcessTimeCard">
-     <property name="minimumSize">
-      <size>
-       <width>50</width>
-       <height>80</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <family>Poppins</family>
-       <pointsize>18</pointsize>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="cursor">
-      <cursorShape>PointingHandCursor</cursorShape>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string>Process Time Card</string>
-     </property>
-     <property name="icon">
-      <iconset>
-       <normaloff>../../MainFrame/Resources/Icons/import.svg</normaloff>../../MainFrame/Resources/Icons/import.svg</iconset>
-     </property>
-     <property name="iconSize">
-      <size>
-       <width>30</width>
-       <height>30</height>
-      </size>
+   <item row="0" column="0">
+    <widget class="QProgressBar" name="progressBar">
+     <property name="value">
+      <number>0</number>
      </property>
     </widget>
    </item>

--- a/MainFrame/TimeKeeping/datImporter/dialogLoader.py
+++ b/MainFrame/TimeKeeping/datImporter/dialogLoader.py
@@ -22,6 +22,9 @@ class dialogModal(QDialog):
         self.importBTN.clicked.connect(self.importTxt)
         self.btnProcessTimeCard.clicked.connect(self.validateToOpen)
 
+        if hasattr(self, 'progressBar'):
+            self.progressBar.setVisible(False)
+
     def importTxt(self, *args):
         fileName, _ = QFileDialog.getOpenFileName(self, "Open DAT File", "", "DAT Files (*.DAT)")
         if fileName:

--- a/MainFrame/TimeKeeping/payTimeSheetImporter/payTimeSheetImporter.py
+++ b/MainFrame/TimeKeeping/payTimeSheetImporter/payTimeSheetImporter.py
@@ -45,11 +45,17 @@ class PayrollDialog(QDialog):
     def __init__(self, main_window):
         super().__init__()
         self.main_window = main_window
-        self.setFixedSize(418, 392)
+        self.setFixedSize(418, 200)
         ui_file = globalFunction.resource_path("MainFrame\\Resources\\UI\\dialogImporter.ui")
         loadUi(ui_file, self)
 
         self.importBTN.clicked.connect(self.importTxt)
+        self.importBTN.setText("Import Excel")
+
+        # Disable the btnProcessTimeCard button
+        if hasattr(self, 'btnProcessTimeCard'):
+            self.btnProcessTimeCard.setVisible(False)
+
         self.progressBar = self.findChild(QProgressBar, 'progressBar')
         self.progressBar.setVisible(False)
 
@@ -57,6 +63,7 @@ class PayrollDialog(QDialog):
         fileName, _ = QFileDialog.getOpenFileName(self, "Select Excel File", "", "Excel Files (*.xls *.xlsx)")
 
         if not fileName:
+            QMessageBox.information(self, "No File Selected", "Please select an Excel file to import.")
             return
 
         # Use FileProcessor to handle the file reading

--- a/MainFrame/TimeKeeping/payTrans/payTransLoader.py
+++ b/MainFrame/TimeKeeping/payTrans/payTransLoader.py
@@ -1,3 +1,5 @@
+
+
 import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/MainFrame/requirements.txt
+++ b/MainFrame/requirements.txt
@@ -17,3 +17,4 @@ PyQt5==5.15.9
 bcrypt==4.2.0
 openpyxl==3.1.5
 psutil==6.0.0
+css-inline==0.14.1


### PR DESCRIPTION
We hide the btnProcessTimeCard to reuse the dialogImporter again
![image](https://github.com/user-attachments/assets/f6710982-b43a-49f0-8d7c-8919ff558b36)

We also hide the progressBar in dialogLoader since it's using the notificationMaker to process the application
![image](https://github.com/user-attachments/assets/8546aaa7-67e6-442b-9343-2b511929a6ef)
