### PR TITLE
PayrollDialog Bug fixed

### DIFF
--- a/MainWindow.py
+++ b/MainWindow.py
@@ -269,9 +269,10 @@ class MainWindow(QMainWindow):
         self.datechange.show()
 
     def openPayRoll(self):
-        if self.payroll_window is None:
-            self.payroll_window = PayrollDialog(self)
-            self.open_dialogs.append(self.payroll_window)
+        if self.payroll_window is not None:
+            self.payroll_window.close()  # Close the previous window if it exists
+        self.payroll_window = PayrollDialog(self)
+        self.open_dialogs.append(self.payroll_window)
         if self.payroll_window.isVisible():
             self.payroll_window.activateWindow()
         else:


### PR DESCRIPTION
The bug within showing buttons based on user role (Paymaster 1 and 2) is now fixed upon logging in and logging out.

- Added a close function to close the previous session window, so that when a new user logs in, the dialog will refresh into a new state of session
![image](https://github.com/user-attachments/assets/c067e209-f0f3-4b02-a8bc-4d07171cbdf7)
