### PR TITLE
Adding attachment in email within Bug Report is now working

### DIFF
--- a/MainFrame/Resources/UI/bugReport.ui
+++ b/MainFrame/Resources/UI/bugReport.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>570</width>
-    <height>370</height>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,11 +17,51 @@
    <iconset>
     <normaloff>../Icons/logo.svg</normaloff>../Icons/logo.svg</iconset>
   </property>
+  <property name="styleSheet">
+   <string notr="true">/* VERTICAL SCROLLBAR */
+QScrollBar:vertical {
+    border: none;
+    background-color: rgba(220, 229, 254, 1); /* Updated background color */
+    width: 12px;
+    margin: 0;
+    height: auto;
+    border-radius: 6px;
+}
+
+/* HANDLE BAR VERTICAL */
+QScrollBar::handle:vertical {
+    background-color: rgba(52, 66, 115, 1); /* Handle color */
+    min-height: 48px;
+    border-radius: 6px;
+    margin-top: 10px;
+}
+
+/* REMOVE THE UP ARROW BUTTON */
+QScrollBar::sub-line:vertical {
+    border: none;
+    background: none;
+    height: 0px;
+    width: 0px;
+}
+
+/* REMOVE THE DOWN ARROW BUTTON */
+QScrollBar::add-line:vertical {
+    border: none;
+    background: none;
+    height: 0px;
+    width: 0px;
+}
+
+/* REMOVE THE SPACE LEFT BY THE UP AND DOWN ARROW BUTTONS */
+QScrollBar::sub-page:vertical, QScrollBar::add-page:vertical {
+    background: none;
+}</string>
+  </property>
   <widget class="QPushButton" name="btnSendReport">
    <property name="geometry">
     <rect>
      <x>410</x>
-     <y>320</y>
+     <y>430</y>
      <width>140</width>
      <height>40</height>
     </rect>
@@ -38,9 +78,15 @@
     <cursorShape>PointingHandCursor</cursorShape>
    </property>
    <property name="styleSheet">
-    <string notr="true">	background-color: &quot;#344273&quot;;
+    <string notr="true">#btnSendReport{
+	background-color: #344273;
 	color: white;
-border-radius: 5px;</string>
+	border-radius: 5px;
+}
+
+#btnSendReport:hover{
+	background-color: rgb(64, 83, 143);
+}</string>
    </property>
    <property name="text">
     <string>Send Report</string>
@@ -60,8 +106,8 @@ border-radius: 5px;</string>
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>320</y>
-     <width>241</width>
+     <y>430</y>
+     <width>211</width>
      <height>41</height>
     </rect>
    </property>
@@ -74,7 +120,7 @@ border-radius: 5px;</string>
     </font>
    </property>
    <property name="text">
-    <string>Message will be sent once reported.</string>
+    <string>Message will be sent to developers once reported.</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignJustify|Qt::AlignVCenter</set>
@@ -89,7 +135,7 @@ border-radius: 5px;</string>
      <x>0</x>
      <y>0</y>
      <width>591</width>
-     <height>71</height>
+     <height>61</height>
     </rect>
    </property>
    <property name="styleSheet">
@@ -107,15 +153,15 @@ border-radius: 5px;</string>
     <property name="geometry">
      <rect>
       <x>20</x>
-      <y>10</y>
+      <y>0</y>
       <width>401</width>
-      <height>51</height>
+      <height>61</height>
      </rect>
     </property>
     <property name="font">
      <font>
       <family>Poppins</family>
-      <pointsize>20</pointsize>
+      <pointsize>16</pointsize>
       <weight>75</weight>
       <bold>true</bold>
      </font>
@@ -137,7 +183,7 @@ background-color: transparent;
    <property name="geometry">
     <rect>
      <x>260</x>
-     <y>320</y>
+     <y>430</y>
      <width>140</width>
      <height>40</height>
     </rect>
@@ -154,10 +200,16 @@ background-color: transparent;
     <cursorShape>PointingHandCursor</cursorShape>
    </property>
    <property name="styleSheet">
-    <string notr="true">background-color: #cccccc;
-color: black;
-border: 1px solid #666666;
-border-radius: 5px;</string>
+    <string notr="true">#btnCancel{
+	background-color: #cccccc;
+	color: black;
+	border: 1px solid #666666;
+	border-radius: 5px;
+}
+
+#btnCancel:hover{
+	background-color: rgb(191, 191, 191);
+}</string>
    </property>
    <property name="text">
     <string>Cancel</string>
@@ -177,9 +229,9 @@ border-radius: 5px;</string>
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>90</y>
+     <y>110</y>
      <width>531</width>
-     <height>211</height>
+     <height>154</height>
     </rect>
    </property>
    <property name="font">
@@ -195,26 +247,160 @@ border-radius: 5px;</string>
     <string>Write your message here. Please include at least 10 characters.</string>
    </property>
   </widget>
-  <widget class="QLabel" name="label_2">
+  <widget class="QLineEdit" name="subjectTxt">
    <property name="geometry">
     <rect>
-     <x>510</x>
-     <y>260</y>
-     <width>31</width>
+     <x>20</x>
+     <y>70</y>
+     <width>531</width>
      <height>31</height>
     </rect>
+   </property>
+   <property name="font">
+    <font>
+     <family>Poppins</family>
+     <pointsize>10</pointsize>
+    </font>
    </property>
    <property name="text">
     <string/>
    </property>
-   <property name="pixmap">
-    <pixmap>../Icons/attachment.svg</pixmap>
+   <property name="placeholderText">
+    <string>Subject</string>
    </property>
-   <property name="scaledContents">
+  </widget>
+  <widget class="QScrollArea" name="attachment_scroll_area">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>320</y>
+     <width>531</width>
+     <height>91</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="styleSheet">
+    <string notr="true"> QScrollBar:vertical {
+	border: none;
+    background: rgba(217, 217, 217, 1);
+ }
+
+#attachment_scroll_area{
+	border: 1px solid #666666;
+}
+
+#attachment_widget{
+	background-color: white;
+}</string>
+   </property>
+   <property name="frameShape">
+    <enum>QFrame::NoFrame</enum>
+   </property>
+   <property name="widgetResizable">
     <bool>true</bool>
+   </property>
+   <widget class="QWidget" name="scroll_contents">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>0</y>
+      <width>529</width>
+      <height>89</height>
+     </rect>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QLabel" name="attachMessage">
+       <property name="font">
+        <font>
+         <family>Poppins</family>
+         <pointsize>10</pointsize>
+         <weight>50</weight>
+         <italic>true</italic>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">#attachMessage{
+	color:rgb(159, 159, 159);
+}</string>
+       </property>
+       <property name="text">
+        <string>Attached Files will be placed here. (Maximum of 3 files)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QPushButton" name="btnAttachFiles">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>270</y>
+     <width>531</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <family>Poppins</family>
+     <pointsize>12</pointsize>
+     <weight>75</weight>
+     <bold>true</bold>
+    </font>
+   </property>
+   <property name="cursor">
+    <cursorShape>PointingHandCursor</cursorShape>
+   </property>
+   <property name="toolTip">
+    <string>Attach Files</string>
+   </property>
+   <property name="layoutDirection">
+    <enum>Qt::LeftToRight</enum>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">#btnAttachFiles{ 
+	background-color: white;
+	border: 1px solid #666666;
+	border-radius: 5px;
+}
+
+#btnAttachFiles:hover {
+	background-color: rgb(238, 238, 238);
+}</string>
+   </property>
+   <property name="text">
+    <string>  Attach Files</string>
+   </property>
+   <property name="icon">
+    <iconset>
+     <normaloff>../Icons/attachment.svg</normaloff>../Icons/attachment.svg</iconset>
+   </property>
+   <property name="iconSize">
+    <size>
+     <width>20</width>
+     <height>20</height>
+    </size>
+   </property>
+   <property name="default">
+    <bool>false</bool>
    </property>
   </widget>
  </widget>
+ <tabstops>
+  <tabstop>subjectTxt</tabstop>
+  <tabstop>bugReportInputTxt</tabstop>
+  <tabstop>btnAttachFiles</tabstop>
+  <tabstop>attachment_scroll_area</tabstop>
+  <tabstop>btnSendReport</tabstop>
+  <tabstop>btnCancel</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/MainFrame/Resources/lib.py
+++ b/MainFrame/Resources/lib.py
@@ -15,7 +15,10 @@ from functools import wraps
 import traceback
 import bcrypt
 import openpyxl
-from email.message import EmailMessage
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.mime.application import MIMEApplication
+from email import encoders
 import ssl
 import smtplib
 import warnings
@@ -30,7 +33,8 @@ from PyQt5.QtGui import QFont, QFontDatabase, QIntValidator, QStandardItemModel,
 from PyQt5.QtWidgets import (
     QMainWindow, QApplication, QVBoxLayout, QFileDialog, QMessageBox, QHeaderView,
     QPushButton, QTableWidgetItem, QPlainTextEdit, QComboBox, QDateEdit, QLineEdit,
-    QDialog, QProgressBar, QLabel, QWidget, QTableWidget, QCheckBox, QStackedWidget
+    QDialog, QProgressBar, QLabel, QWidget, QTableWidget, QCheckBox, QStackedWidget,
+    QHBoxLayout
 )
 from PyQt5.uic import loadUi
 from MainFrame.systemFunctions import single_function_logger

--- a/MainFrame/bugReport.py
+++ b/MainFrame/bugReport.py
@@ -1,3 +1,5 @@
+import os.path
+
 from MainFrame.Resources.lib import *
 from email.utils import formataddr
 from MainFrame.Database_Connection.user_session import UserSession
@@ -11,24 +13,90 @@ class BugReportModal(QDialog):
         super(BugReportModal, self).__init__()
         ui_file = globalFunction.resource_path("MainFrame\\Resources\\UI\\bugReport.ui")
         loadUi(ui_file, self)
-        self.setFixedSize(570, 370)
+        self.setFixedSize(570, 480)
 
         self.user_session = UserSession().getALLSessionData()
 
+        self.attachment_scroll_area = self.findChild(QtWidgets.QScrollArea, 'attachment_scroll_area')
+        self.scroll_layout = self.scroll_contents.layout()
+
         self.bugReportInputTxt = self.findChild(QPlainTextEdit, "bugReportInputTxt")
 
+        self.btnAttachFiles.clicked.connect(self.attach_files)
         self.btnSendReport.clicked.connect(self.sendBugReport)
         self.btnCancel.clicked.connect(self.cancelBtn)
 
-    def cancelBtn(self):
-        self.bugReportInputTxt.clear()
-        self.close()
+        # Store attachments
+        self.attachments = []
 
-    def sendBugReport(self, checked=False):
+    def attach_files(self):
+        """Handles all the attached files and append them"""
+        if len(self.attachments) > 3:
+            QMessageBox.warning(self, 'Limit Reached', 'You can only attach up to 3 files.')
+            return
+
+        files, _ = QFileDialog.getOpenFileNames(self, 'Select Files')
+
+        if files:
+            for file in files:
+                if len(self.attachments) < 3:
+                    self.attachments.append(file)
+                    self.add_attachment_container(file)
+                else:
+                    QMessageBox.warning(self, 'Limit Reached', 'You can only attach up to 3 files.')
+                    break
+
+    def add_attachment_container(self, file_path):
+        """Adds a container for file if there's any attached files"""
+        file_name = os.path.basename(file_path)
+
+        # Creates an attachment container for each uploaded attachment
+        attachment_container = QWidget(self)
+        attachment_layout = QHBoxLayout(attachment_container)
+        attachment_container.setStyleSheet("background-color: #cccccc; border-radius: 5px;")
+        attachment_container.setMaximumHeight(50)
+        attachment_layout.setContentsMargins(10, 0, 10, 0)
+        
+        # Displays the file name
+        file_label = QLabel(file_name, self)
+        file_label.setStyleSheet("font-family: Poppins; font-size: 12px;")
+        attachment_layout.addWidget(file_label)
+
+        # Creates remove Attachment button
+        remove_button = QPushButton('x', self)
+        remove_button.setFixedSize(30, 30)
+        remove_button.setCursor(Qt.PointingHandCursor)
+        remove_button.setStyleSheet("font-family: Poppins; font-size: 25px; color: black; "
+                                    "background-color: none; border: none;")
+        remove_button.clicked.connect(lambda: self.remove_attachment(file_path, attachment_container))
+        attachment_layout.addWidget(remove_button)
+
+        self.scroll_layout.addWidget(attachment_container)
+
+        if len(self.attachments) > 0:
+            self.attachMessage.hide()
+            return
+
+    def remove_attachment(self, file_path, attachment_container):
+        # Remove the file from the attachment list and the widget
+        if file_path in self.attachments:
+            self.attachments.remove(file_path)
+            self.scroll_layout.removeWidget(attachment_container)
+            attachment_container.deleteLater()
+
+        if len(self.attachments) == 0:
+            self.attachMessage.show()
+
+    def sendBugReport(self):
+        subjectTxt = self.subjectTxt.text().strip()
         bugReportTxt = self.bugReportInputTxt.toPlainText().strip()
 
+        if not subjectTxt:
+            QMessageBox.warning(self, "Input Error", "Please fill out the Subject!")
+            return
+
         if not bugReportTxt or len(bugReportTxt) < 10:
-            QMessageBox.warning(self, "Input Error", "Please enter at least 10 characters")
+            QMessageBox.warning(self, "Input Error", "Please enter at least 10 characters!")
             return
 
         # Show wait message while being sent
@@ -47,24 +115,29 @@ class BugReportModal(QDialog):
         # Email Receivers
         developers_email = ['rodelcuyag123@gmail.com', 'badlonmazeclarion@gmail.com', 'jhayemcalleja011@gmail.com']
 
-        date_sent = date.today()
-
-        subject = f'Bug Report - {date_sent}'
+        subject = subjectTxt
         body = self.prepare_email_body(bugReportTxt)
 
         context = ssl.create_default_context()
+
+        msg = MIMEMultipart()
+        msg['From'] = formataddr((f"{sender_name}", f"{email_sender}"))  # Displays the user_name as sender
+        msg['Bcc'] = ', '.join(developers_email)  # Concatenates all dev emails
+        msg['Subject'] = subject
+        msg.attach(MIMEText(body, _subtype='html'))
+
+        # Attach Files in email
+        for attachment in self.attachments:
+            with open(attachment, 'rb') as file:
+                part = MIMEApplication(file.read())
+                part['Content-Disposition'] = 'attachment; filename="{}"'.format(os.path.basename(attachment))
+                msg.attach(part)
 
         try:
             with smtplib.SMTP_SSL('smtp.gmail.com', 465, context=context) as smtp:
                 smtp.login(email_sender, email_password)
 
-                em = EmailMessage()
-                em['From'] = formataddr((f"{sender_name}", f"{email_sender}"))  # Displays the user_name as sender
-                em['Bcc'] = ', '.join(developers_email)  # Concatenates all dev emails
-                em['Subject'] = subject
-                em.add_alternative(body, subtype='html')
-
-                if self.send_email(em, smtp):
+                if self.send_email(msg, smtp):
                     msg_box.done(QMessageBox.Ok)  # closes the wait message on success
                     QMessageBox.information(self, "Report Sent", "Report sent successfully!")
                     self.cancelBtn()
@@ -105,11 +178,30 @@ class BugReportModal(QDialog):
 
         return body
 
-    def send_email(self, em, smtp):
+    def send_email(self, msg, smtp):
         # Sends email to each receiver
         try:
-            smtp.send_message(em)
+            smtp.send_message(msg)
         except Exception as e:
             logging.warning(f"Failed to send email: {e}")
             return False
         return True
+
+    def cancelBtn(self):
+        """Clears the bug report inputs and removes all attachments before closing the dialog"""
+        # Clear the text input
+        self.bugReportInputTxt.clear()
+        self.subjectTxt.clear()
+
+        # Remove all attachment containers and clear the attachments list
+        while self.scroll_layout.count() > 0:
+            item = self.scroll_layout.takeAt(0)
+            if item:
+                widget = item.widget()
+                if widget and widget is not self.attachMessage:
+                    self.scroll_layout.removeWidget(widget)
+                    widget.deleteLater()
+
+        self.attachments.clear()
+        self.attachMessage.show()
+        self.close()

--- a/MainFrame/main_functions.py
+++ b/MainFrame/main_functions.py
@@ -279,6 +279,7 @@ class MainWindowFunctions(QMainWindow):
         if self.bugReportModal.isVisible():
             self.bugReportModal.activateWindow()
         else:
+            self.bugReportModal.finished.connect(self.bugReportModal.cancelBtn)
             self.bugReportModal.show()
 
     def resource_path(self, relative_path):


### PR DESCRIPTION
- UI modification in bugReport.ui
![image](https://github.com/user-attachments/assets/39770092-49b4-43a2-a08c-f9ecd73630ff)

- In attaching a file, the user can only attach 3 maximum files only.
![image](https://github.com/user-attachments/assets/c812563a-170a-40b7-85e1-8e687da927a8)

- The user can add and remove an attached file which are defined in these following functions:
![image](https://github.com/user-attachments/assets/c7f6b238-9cfb-4540-b900-aa816ddeb1e3)

- When a certain user decide to cancel the report, all inputs will be remove including the attached files
![image](https://github.com/user-attachments/assets/64ac252f-6ab6-46c3-a04d-dbfd8d49c74f)

NOTE: this feature is an optional approach if the user wants to attach some files within an email, they can still send an email even without attaching files.