### PR TITLE
Updated UI Column Names 

### DIFF
--- a/MainFrame/Resources/UI/TimeSheet.ui
+++ b/MainFrame/Resources/UI/TimeSheet.ui
@@ -259,7 +259,7 @@ QTableWidget {
     <bool>false</bool>
    </property>
    <property name="columnCount">
-    <number>17</number>
+    <number>25</number>
    </property>
    <attribute name="horizontalHeaderVisible">
     <bool>true</bool>
@@ -351,52 +351,92 @@ QTableWidget {
    </column>
    <column>
     <property name="text">
-     <string>Ordinary Day</string>
+     <string>OrdDay</string>
     </property>
    </column>
    <column>
     <property name="text">
-     <string>Ordinary Day OT</string>
+     <string>OrdDay OT</string>
     </property>
    </column>
    <column>
     <property name="text">
-     <string>Ordinary Day ND</string>
+     <string>OrdDay ND</string>
     </property>
    </column>
    <column>
     <property name="text">
-     <string>Ordinary Day ND OT</string>
+     <string>OrdDay NDOT</string>
     </property>
    </column>
    <column>
     <property name="text">
-     <string>Regular Holiday</string>
+     <string>RD</string>
     </property>
    </column>
    <column>
     <property name="text">
-     <string>Regular Holiday ND</string>
+     <string>RD OT</string>
     </property>
    </column>
    <column>
     <property name="text">
-     <string>Regular Holiday ND OT</string>
+     <string>RD ND</string>
     </property>
    </column>
    <column>
     <property name="text">
-     <string>Late</string>
+     <string>RD NDOT</string>
     </property>
    </column>
    <column>
     <property name="text">
-     <string>Absent</string>
+     <string>SHLDy</string>
     </property>
    </column>
    <column>
     <property name="text">
-     <string>Date Posted</string>
+     <string>SHLDy OT</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>SHLDy ND</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>SHLDy NDOT</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>RegHldy</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>RegHldy OT</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>SHLDyRD </string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>SHLDyRD OT</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>RegHldyRD</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>RegHldyRD OT</string>
     </property>
    </column>
   </widget>

--- a/MainFrame/Resources/UI/paytrans.ui
+++ b/MainFrame/Resources/UI/paytrans.ui
@@ -112,7 +112,7 @@ QTableWidget {
      <bool>false</bool>
     </property>
     <property name="columnCount">
-     <number>23</number>
+     <number>24</number>
     </property>
     <attribute name="horizontalHeaderVisible">
      <bool>true</bool>
@@ -219,67 +219,72 @@ QTableWidget {
     </column>
     <column>
      <property name="text">
-      <string>Payded_1</string>
+      <string>Late/Absent</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_2</string>
+      <string>SSS_Loan</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_3</string>
+      <string>Pagibig_Loan</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_4</string>
+      <string>Cash_Advance</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_5</string>
+      <string>Canteen</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_6</string>
+      <string>Tax</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_7</string>
+      <string>SSS</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_8</string>
+      <string>Medicare/Philhealth</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_9</string>
+      <string>Pagibig</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_10</string>
+      <string>Clinic</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_11</string>
+      <string>Arayata_Annual</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_12</string>
+      <string>HMI</string>
      </property>
     </column>
     <column>
      <property name="text">
-      <string>Payded_14</string>
+      <string>Funeral</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>Voluntary</string>
      </property>
     </column>
    </widget>


### PR DESCRIPTION
Updated Column names in PayTrans (UI)

- PayDed 1 to 14 into Deduction Column Names
**Before**
![image](https://github.com/user-attachments/assets/f1ab3795-f42f-4172-b635-4fd2d3c874ed)
**After**
![image](https://github.com/user-attachments/assets/d436d096-893f-4112-b121-46ee90fe01e0)


Renamed Column names in Timesheet (UI)

**Before**
![image](https://github.com/user-attachments/assets/13e680ba-1ff6-42ce-8c27-2c24e2159f98)
**After**
![image](https://github.com/user-attachments/assets/063da140-0f56-4992-8620-92efbe3ac569)

_Refer to the image below_
![image](https://github.com/user-attachments/assets/33cd7137-fe60-414d-95a4-04d3921d9664)

