### PR TITLE
Optimize fetching data in Timecard

### DIFF
--- a/MainFrame/Resources/lib.py
+++ b/MainFrame/Resources/lib.py
@@ -34,7 +34,7 @@ from PyQt5.QtWidgets import (
     QMainWindow, QApplication, QVBoxLayout, QFileDialog, QMessageBox, QHeaderView,
     QPushButton, QTableWidgetItem, QPlainTextEdit, QComboBox, QDateEdit, QLineEdit,
     QDialog, QProgressBar, QLabel, QWidget, QTableWidget, QCheckBox, QStackedWidget,
-    QHBoxLayout
+    QHBoxLayout, QStyledItemDelegate, QAbstractItemView
 )
 from PyQt5.uic import loadUi
 from MainFrame.systemFunctions import single_function_logger


### PR DESCRIPTION
Optimization of fetching log import data in timecard

Adjusted the populate_table_with_data function:

1. Instead of including the combo_items values for 24 hour format inside the for loop for combo box population, it is now prepopulated outside the loop.

![image](https://github.com/user-attachments/assets/5e796828-8ca0-40ea-afdb-2fad4ab035a1)

2. The condition added within the for loop ensures that the column 6 and 7 (time_in and time_out) is the only cell that can be editable.

![image](https://github.com/user-attachments/assets/67a6aeaa-c9bf-4ae8-97c2-8e3f8b880044)


Adjusted how the combox work in time_in and time_out:

1. Created a new class that will handle itemDelegates inside TimeListTable, this will only create a combox if the time_in or time_out column is currently editable.

![image](https://github.com/user-attachments/assets/1d5c9586-e438-45d1-ad05-49c20885bcc7)

 