### PR TITLE
Added RD, Holiday, and Night Diff OT Computation

### DIFF
--- a/MainFrame/Payroll/payroll_functions/payComputations.py
+++ b/MainFrame/Payroll/payroll_functions/payComputations.py
@@ -61,6 +61,26 @@ class PayComputation:
             item['RegDayNightDiffEarn'] = round(regular_day_night_value, 2)
             logging.info(f"Calculated regular day night diff for EmpNo {item['EmpNo']}: {item['RegDayNightDiffEarn']}")
 
+    def regularDayNightDiffOTComputation(self):
+        for item in self.data:
+            try:
+                hourly_rate = float(item.get('Rate') if item.get('Rate') != 'Missing' else 0) / 8
+                reg_day_nd_ot_hours = float(
+                    item.get('Regular Day Night Diff OT') if item.get(
+                        'Regular Day Night Diff OT') != 'Missing' else 0)
+            except ValueError as e:
+                logging.error(f"Error converting Reg Day ND OT and hourly rate value for EmpNo {item['EmpNo']}: {e}")
+                hourly_rate = 0
+                reg_day_nd_ot_hours = 0
+
+            # Regular Day Night Differential Overtime Computation
+            overtime_rate = 1.25   # Overtime Rate of 120%
+            night_diff_rate = 1.1  # Night Differential Rate of 110%
+            reg_day_nd_ot_value = hourly_rate * overtime_rate * night_diff_rate * reg_day_nd_ot_hours
+
+            item['RegDayNightDiffOTEarn'] = round(reg_day_nd_ot_value, 2)
+            logging.info(f"Calculated reg day nd ot value for EmpNo {item['EmpNo']}: {item['RegDayNightDiffOTEarn']}")
+
     def lateComputation(self):
         late_rate = 59.875  # Define the late
         scaling_factor = 10  # Define the scaling factor to adjust 'Late' values
@@ -104,3 +124,95 @@ class PayComputation:
 
             item['undertime'] = round(Undertime_value, 2)
             logging.info(f"Calculated late value for EmpNo {item['EmpNo']}: {item['undertime']}")
+
+    def restDayComputation(self):
+        for item in self.data:
+            try:
+                hourly_rate = float(item.get('Rate') if item.get('Rate') != 'Missing' else 0) / 8
+                rest_day_hours = float(item.get('Rest Day Hours') if item.get('Rest Day Hours') != 'Missing' else 0)
+            except ValueError as e:
+                logging.error(f"Error converting Rest Day and hourly rate value for EmpNo {item['EmpNo']}: {e}")
+                hourly_rate = 0
+                rest_day_hours = 0
+
+            # Rest Day Rate Computation
+            rest_day_rate = 1.3 # rest day rate value (equivalent to 130%)
+            rest_day_rate_per_hour = hourly_rate * rest_day_rate
+
+            rest_day_rate_total = rest_day_hours * rest_day_rate_per_hour
+
+            item['RestDay_Earn'] = round(rest_day_rate_total, 2)
+            logging.info(f"Calculated rest day value for EmpNo {item['EmpNo']}: {item['RestDay_Earn']}")
+
+    def restDayOTComputation(self):
+        for item in self.data:
+            try:
+                hourly_rate = float(item.get('Rate') if item.get('Rate') != 'Missing' else 0) / 8
+                rest_day_ot_hours = float(item.get('Rest Day OT Hours') if item.get('Rest Day OT Hours') != 'Missing' else 0)
+            except ValueError as e:
+                logging.error(f"Error converting Rest Day OT and hourly rate value for EmpNo {item['EmpNo']}: {e}")
+                hourly_rate = 0
+                rest_day_ot_hours = 0
+
+            item['RestDayOT_Earn'] = round(0.0, 2)
+            logging.info(f"Calculated rest day ot value for EmpNo {item['EmpNo']}: {item['RestDayOT_Earn']}")
+
+    def restDayNightDiffComputation(self):
+        for item in self.data:
+            try:
+                hourly_rate = float(item.get('Rate') if item.get('Rate') != 'Missing' else 0) / 8
+                rest_day_nd_hours = float(
+                    item.get('Rest Day Night Diff Hours') if item.get('Rest Day Night Diff Hours') != 'Missing' else 0)
+            except ValueError as e:
+                logging.error(f"Error converting Rest Day ND and hourly rate value for EmpNo {item['EmpNo']}: {e}")
+                hourly_rate = 0
+                rest_day_nd_hours = 0
+
+            item['RestDayND_Earn'] = round(0.0, 2)
+            logging.info(f"Calculated rest day nd value for EmpNo {item['EmpNo']}: {item['RestDayND_Earn']}")
+
+    def regularHolidayComputation(self):
+        for item in self.data:
+            try:
+                hourly_rate = float(item.get('Rate') if item.get('Rate') != 'Missing' else 0) / 8
+                holiday_hours = float(item.get('Holiday Hours') if item.get('Holiday Hours') != 'Missing' else 0)
+            except ValueError as e:
+                logging.error(f"Error converting Holiday and hourly rate value for EmpNo {item['EmpNo']}: {e}")
+                hourly_rate = 0
+                holiday_hours = 0
+
+            # Holiday Rate Computation
+            holiday_rate = 2  # holiday rate value (equivalent to 200%)
+            holiday_rate_per_hour = hourly_rate * holiday_rate
+
+            holiday_rate_total = holiday_hours * holiday_rate_per_hour
+
+            item['HolidayDay_Earn'] = round(holiday_rate_total, 2)
+            logging.info(f"Calculated holiday value for EmpNo {item['EmpNo']}: {item['HolidayDay_Earn']}")
+
+    def regularHolidayOTComputation(self):
+        for item in self.data:
+            try:
+                hourly_rate = float(item.get('Rate') if item.get('Rate') != 'Missing' else 0) / 8
+                holiday_ot_hours = float(item.get('Holiday OT Hours') if item.get('Holiday OT Hours') != 'Missing' else 0)
+            except ValueError as e:
+                logging.error(f"Error converting Holiday OT and hourly rate value for EmpNo {item['EmpNo']}: {e}")
+                hourly_rate = 0
+                holiday_ot_hours = 0
+
+            item['HolidayDayOT_Earn'] = round(0.0, 2)
+            logging.info(f"Calculated holiday ot value for EmpNo {item['EmpNo']}: {item['HolidayDayOT_Earn']}")
+
+    def regularHolidayNightDiffComputation(self):
+        for item in self.data:
+            try:
+                hourly_rate = float(item.get('Rate') if item.get('Rate') != 'Missing' else 0) / 8
+                holiday_nd_hours = float(
+                    item.get('Holiday Night Diff Hours') if item.get('Holiday Night Diff Hours') != 'Missing' else 0)
+            except ValueError as e:
+                logging.error(f"Error converting Holiday OT and hourly rate value for EmpNo {item['EmpNo']}: {e}")
+                hourly_rate = 0
+                holiday_nd_hours = 0
+
+            item['HolidayDayND_Earn'] = round(0.0, 2)
+            logging.info(f"Calculated holiday ot value for EmpNo {item['EmpNo']}: {item['HolidayDayOT_Earn']}")

--- a/MainFrame/Payroll/payroll_functions/payTransFunctions.py
+++ b/MainFrame/Payroll/payroll_functions/payTransFunctions.py
@@ -28,10 +28,17 @@ class PayTransFunctions:
             basic_item = QTableWidgetItem(str(row['Basic']))
             present_days_item = QTableWidgetItem(row['Present Days'])
             reg_day_night_diff_item = QTableWidgetItem(str(row['RegDayNightDiffEarn']))
+            reg_day_night_diff_ot_item = QTableWidgetItem(str(row['RegDayNightDiffOTEarn']))
             rate_item = QTableWidgetItem(row.get('Rate', 'Missing'))  # Get rate or 'Missing' if not found
             ot_earn_item = QTableWidgetItem(str(row['OT_Earn']))  # Get OT_Earn or '0.00' if not found
             late_earn_item = QTableWidgetItem(str(row['LateUndertime']))
             undertime_earn_item = QTableWidgetItem(str(row['undertime']))
+            rest_day_earn_item = QTableWidgetItem(str(row['RestDay_Earn']))
+            holiday_earn_item = QTableWidgetItem(str(row['HolidayDay_Earn']))
+            rest_day_ot_earn_item = QTableWidgetItem(str(row['RestDayOT_Earn']))
+            holiday_ot_earn_item = QTableWidgetItem(str(row['HolidayDayOT_Earn']))
+            rest_day_nd_earn_item = QTableWidgetItem(str(row['RestDayND_Earn']))
+            holiday_nd_earn_item = QTableWidgetItem(str(row['HolidayDayND_Earn']))
 
             # deduction items
             absent_earn_item = QTableWidgetItem(str(row.get('late_absent', '0')))
@@ -52,9 +59,11 @@ class PayTransFunctions:
             # Center all the items
             for item in [emp_no_item, bio_num_item, emp_name_item, basic_item, present_days_item, rate_item,
                          ot_earn_item, late_earn_item, undertime_earn_item, reg_day_night_diff_item,
-                         absent_earn_item, sss_loan_earn_item, pagibig_loan_earn_item, cash_earn_item,
-                         canteen_earn_item, tax_earn_item, sss_earn_item, philhealth_earn_item, pagibig_earn_item,
-                         clinic_earn_item, arayata_earn_item, hmi_earn_item, funeral_earn_item,
+                         reg_day_night_diff_ot_item, rest_day_earn_item,
+                         rest_day_ot_earn_item, rest_day_nd_earn_item, holiday_earn_item, holiday_ot_earn_item,
+                         holiday_nd_earn_item, absent_earn_item, sss_loan_earn_item, pagibig_loan_earn_item,
+                         cash_earn_item, canteen_earn_item, tax_earn_item, sss_earn_item, philhealth_earn_item,
+                         pagibig_earn_item, clinic_earn_item, arayata_earn_item, hmi_earn_item, funeral_earn_item,
                          voluntary_earn_item]:
                 item.setTextAlignment(Qt.AlignCenter)
 
@@ -66,23 +75,30 @@ class PayTransFunctions:
             self.parent.paytransTable.setItem(i, 4, rate_item)   # Rate
             self.parent.paytransTable.setItem(i, 5, present_days_item)  # Present Days
             self.parent.paytransTable.setItem(i, 6, ot_earn_item)  # OT Hours (add column index here)
-            self.parent.paytransTable.setItem(i, 7, reg_day_night_diff_item)
-            self.parent.paytransTable.setItem(i, 8, late_earn_item)
-            self.parent.paytransTable.setItem(i, 9, undertime_earn_item)
-            self.parent.paytransTable.setItem(i, 10, absent_earn_item)
-            self.parent.paytransTable.setItem(i, 11, sss_loan_earn_item)
-            self.parent.paytransTable.setItem(i, 12, pagibig_loan_earn_item)
-            self.parent.paytransTable.setItem(i, 13, cash_earn_item)
-            self.parent.paytransTable.setItem(i, 14, canteen_earn_item)
-            self.parent.paytransTable.setItem(i, 15, tax_earn_item)
-            self.parent.paytransTable.setItem(i, 16, sss_earn_item)
-            self.parent.paytransTable.setItem(i, 17, philhealth_earn_item)
-            self.parent.paytransTable.setItem(i, 18, pagibig_earn_item)
-            self.parent.paytransTable.setItem(i, 19, clinic_earn_item)
-            self.parent.paytransTable.setItem(i, 20, arayata_earn_item)
-            self.parent.paytransTable.setItem(i, 21, hmi_earn_item)
-            self.parent.paytransTable.setItem(i, 22, funeral_earn_item)
-            self.parent.paytransTable.setItem(i, 23, voluntary_earn_item)
+            self.parent.paytransTable.setItem(i, 7, reg_day_night_diff_item)    # Regular Night Diff
+            self.parent.paytransTable.setItem(i, 8, reg_day_night_diff_ot_item)    # Regular Night Diff OT
+            self.parent.paytransTable.setItem(i, 9, rest_day_earn_item)    # Rest day earn
+            self.parent.paytransTable.setItem(i, 10, rest_day_ot_earn_item)  # Rest day OT earn
+            self.parent.paytransTable.setItem(i, 11, rest_day_nd_earn_item)  # Rest day ND earn
+            self.parent.paytransTable.setItem(i, 12, holiday_earn_item)   # Holiday earn
+            self.parent.paytransTable.setItem(i, 13, holiday_ot_earn_item)  # Holiday OT earn
+            self.parent.paytransTable.setItem(i, 14, holiday_nd_earn_item)  # Holiday ND earn
+            self.parent.paytransTable.setItem(i, 15, late_earn_item)
+            self.parent.paytransTable.setItem(i, 16, undertime_earn_item)
+            self.parent.paytransTable.setItem(i, 17, absent_earn_item)
+            self.parent.paytransTable.setItem(i, 18, sss_loan_earn_item)
+            self.parent.paytransTable.setItem(i, 19, pagibig_loan_earn_item)
+            self.parent.paytransTable.setItem(i, 20, cash_earn_item)
+            self.parent.paytransTable.setItem(i, 21, canteen_earn_item)
+            self.parent.paytransTable.setItem(i, 22, tax_earn_item)
+            self.parent.paytransTable.setItem(i, 23, sss_earn_item)
+            self.parent.paytransTable.setItem(i, 24, philhealth_earn_item)
+            self.parent.paytransTable.setItem(i, 25, pagibig_earn_item)
+            self.parent.paytransTable.setItem(i, 26, clinic_earn_item)
+            self.parent.paytransTable.setItem(i, 27, arayata_earn_item)
+            self.parent.paytransTable.setItem(i, 28, hmi_earn_item)
+            self.parent.paytransTable.setItem(i, 29, funeral_earn_item)
+            self.parent.paytransTable.setItem(i, 30, voluntary_earn_item)
 
     def export_to_excel(self, checked=False):
         # Define the file name where data will be saved

--- a/MainFrame/Payroll/payroll_functions/paytimeSheetFunctions.py
+++ b/MainFrame/Payroll/payroll_functions/paytimeSheetFunctions.py
@@ -61,10 +61,20 @@ class PaytimeSheetFunctions:
             bio_num_item = self.parent.paytimesheetTable.item(row, 1)
             emp_name_item = self.parent.paytimesheetTable.item(row, 2)
             present_days_item = self.parent.paytimesheetTable.item(row, 5)
+            rest_day_item = self.parent.paytimesheetTable.item(row, 6)
+            holiday_item = self.parent.paytimesheetTable.item(row, 7)
+            restholiday_item = self.parent.paytimesheetTable.item(row, 8)
             reg_day_night_diff_item = self.parent.paytimesheetTable.item(row, 9)
-            ordinary_day_ot_item = self.parent.paytimesheetTable.item(row, 13)
-            late_item = self.parent.paytimesheetTable.item(row, 17)
-            undertime_item = self.parent.paytimesheetTable.item(row, 18)
+            reg_day_night_diff_ot_item = self.parent.paytimesheetTable.item(row, 10)
+            rest_day_night_item = self.parent.paytimesheetTable.item(row, 11)
+            holiday_night_item = self.parent.paytimesheetTable.item(row, 12)
+            rest_holiday_night_item = self.parent.paytimesheetTable.item(row, 13)
+            ordinary_day_ot_item = self.parent.paytimesheetTable.item(row, 14)
+            rest_day_ot_item = self.parent.paytimesheetTable.item(row, 15)
+            holiday_ot_item = self.parent.paytimesheetTable.item(row, 16)
+            restholiday_ot_item = self.parent.paytimesheetTable.item(row, 17)
+            late_item = self.parent.paytimesheetTable.item(row, 18)
+            undertime_item = self.parent.paytimesheetTable.item(row, 19)
 
             if bio_num_item and bio_num_item.text():
                 bio_num = bio_num_item.text()[3:]
@@ -76,8 +86,15 @@ class PaytimeSheetFunctions:
                 'BioNum': bio_num,
                 'EmpName': emp_name_item.text(),
                 'Present Days': present_days_item.text(),
+                'Rest Day Hours': rest_day_item.text(),
+                'Holiday Hours': holiday_item.text(),
                 'Regular Day Night Diff': reg_day_night_diff_item.text(),
+                'Regular Day Night Diff OT': reg_day_night_diff_ot_item.text(),
+                'Rest Day Night Diff Hours': rest_day_night_item.text(),
+                'Holiday Night Diff Hours': holiday_night_item.text(),
                 'OrdinaryDayOT': ordinary_day_ot_item.text(),
+                'Rest Day OT Hours': rest_day_ot_item.text(),
+                'Holiday OT Hours': holiday_ot_item.text(),
                 'Late': late_item.text(),
                 'Undertime': undertime_item.text()
             })
@@ -93,8 +110,17 @@ class PaytimeSheetFunctions:
         pay_computation.basicComputation()
         pay_computation.overtimeComputation()
         pay_computation.regularDayNightDiffComputation()
+        pay_computation.regularDayNightDiffOTComputation()
         pay_computation.lateComputation()
         pay_computation.undertimeComputation()
+        pay_computation.restDayComputation()
+        pay_computation.regularHolidayComputation()
+        pay_computation.restDayOTComputation()
+        pay_computation.regularHolidayOTComputation()
+        pay_computation.restDayNightDiffComputation()
+        pay_computation.regularHolidayNightDiffComputation()
+
+        print("Data with new computation: \n\t", selected_data)
 
         try:
             self.parent.window = PayTrans(from_date, to_date, selected_data)
@@ -173,6 +199,7 @@ class PaytimeSheetFunctions:
             'Holiday': 'holiday',
             'RestHoliday': 'rsthlyday',
             'OrdinaryDayNight': 'orddaynite',
+            'OrdinaryDayNightOT': 'orddaynit2',
             'RestDayNight': 'rstdaynite',
             'HolidayNight': 'hlydaynite',
             'RestHolidayNight': 'rsthlydayn',

--- a/MainFrame/Resources/UI/paytimesheet.ui
+++ b/MainFrame/Resources/UI/paytimesheet.ui
@@ -112,7 +112,7 @@ QTableWidget {
      <bool>false</bool>
     </property>
     <property name="columnCount">
-     <number>24</number>
+     <number>25</number>
     </property>
     <attribute name="horizontalHeaderVisible">
      <bool>true</bool>
@@ -215,6 +215,11 @@ QTableWidget {
     <column>
      <property name="text">
       <string>OrdinaryDayNight</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>OrdinaryDayNightOT</string>
      </property>
     </column>
     <column>

--- a/MainFrame/Resources/UI/paytrans.ui
+++ b/MainFrame/Resources/UI/paytrans.ui
@@ -15,7 +15,7 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>../Icons/logo.svg</normaloff>../Icons/logo.svg</iconset>
+    <normaloff>C:/Users/Acer/.designer/Icons/logo.svg</normaloff>C:/Users/Acer/.designer/Icons/logo.svg</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
    <widget class="QTableWidget" name="paytransTable">
@@ -112,7 +112,7 @@ QTableWidget {
      <bool>false</bool>
     </property>
     <property name="columnCount">
-     <number>24</number>
+     <number>31</number>
     </property>
     <attribute name="horizontalHeaderVisible">
      <bool>true</bool>
@@ -205,6 +205,41 @@ QTableWidget {
     <column>
      <property name="text">
       <string>Regular Night Diff</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>Regular Night Diff OT</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>RestDay_Earn</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>RestDayOT_Earn</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>RestDayND_Earn</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>Holiday_Earn</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>HolidayOT_Earn</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>HolidayND_Earn</string>
      </property>
     </column>
     <column>
@@ -489,7 +524,7 @@ background-color: #c75657;
         </property>
         <property name="icon">
          <iconset>
-          <normaloff>../Icons/export.svg</normaloff>../Icons/export.svg</iconset>
+          <normaloff>C:/Users/Acer/.designer/Icons/export.svg</normaloff>C:/Users/Acer/.designer/Icons/export.svg</iconset>
         </property>
         <property name="iconSize">
          <size>
@@ -559,7 +594,7 @@ background-color: #c75657;
         </property>
         <property name="icon">
          <iconset>
-          <normaloff>../Icons/mail.svg</normaloff>../Icons/mail.svg</iconset>
+          <normaloff>C:/Users/Acer/.designer/Icons/mail.svg</normaloff>C:/Users/Acer/.designer/Icons/mail.svg</iconset>
         </property>
         <property name="iconSize">
          <size>
@@ -647,7 +682,7 @@ background-color: #c75657;
        <string/>
       </property>
       <property name="pixmap">
-       <pixmap>../Icons/search.svg</pixmap>
+       <pixmap>C:/Users/Acer/.designer/Icons/search.svg</pixmap>
       </property>
       <property name="scaledContents">
        <bool>false</bool>

--- a/MainFrame/systemFunctions.py
+++ b/MainFrame/systemFunctions.py
@@ -79,6 +79,7 @@ class FileProcessor(QObject):
             'holiday': ['holiday'],
             'rsthlyday': ['rsthlyday'],
             'orddaynite': ['orddaynite'],
+            'orddaynit2': ['orddaynit2'],
             'rstdaynite': ['rstdaynite'],
             'hlydaynite': ['hlydaynite'],
             'rsthlydayn': ['rsthlydayn'],
@@ -117,7 +118,7 @@ class FileProcessor(QObject):
                 sheet = workbook.sheet_by_index(0)
                 headers = sheet.row_values(0)
                 total_rows = sheet.nrows
-                for row_idx in range(1, total_rows):  # Skip header row
+                for row_idx in range(0, total_rows):  # Skip header row
                     row = sheet.row_values(row_idx)
                     content.append(row)
                     progress = int((row_idx / total_rows) * 100)


### PR DESCRIPTION
- The following are the newly added computational functions in payComputations.py for PayTrans:

![image](https://github.com/user-attachments/assets/56cecfbd-3e4b-49f3-ad66-ca1825c98b71)
![image](https://github.com/user-attachments/assets/5688cf2d-a677-4232-a96e-bc5e7443513f)

- Added new columns in paytimesheet and paytrans ui based on the added computations

- Fixed the fetching row 2 (with an employee name data of 'Abadejas') in paytimesheet and paytrans 

- Population with the new added computation data within paytimesheet and paytrans table is already added

NOTE: The following computational function doesn't have real computation yet and it only returns '0.0' so that it would populate in the table: restDayOTComputation, restDayNightDiffComputation, regularHolidayNightDiffComputation, and regularHolidayOTComputation, 
