### PR TITLE
HolidayType

### DIFF
--- a/MainFrame/notificationMaker.py
+++ b/MainFrame/notificationMaker.py
@@ -266,10 +266,7 @@ class FileProcessor(QObject):
                             ON DUPLICATE KEY UPDATE
                             machCode = VALUES(machCode),
                             time_in = VALUES(time_in),
-                            time_out = VALUES(time_out),
-                            Name = VALUES(Name),
-                            sched_in = VALUES(sched_in),
-                            sched_out = VALUES(sched_out)
+                            time_out = VALUES(time_out)
                         """)
 
                         # Execute the insert with the fetched employee data


### PR DESCRIPTION
Correcting holiday type checking by fixing the date format and adding calculations for special and regular holiday hours.

- Trans_date is formatted as a string in YYYY-MM-DD. If trans_date is not a string, the method returns None and it checks the type_of_dates table to find holiday names and types associated with trans_date.
![image](https://github.com/user-attachments/assets/4ce5d195-82f3-40ef-af61-a4dd8cd151c3)

- It retrieves holidayName and dateType from the query result which will output like this:
![image](https://github.com/user-attachments/assets/d4f27476-c397-4981-96d6-e8f709a98336)

- Added a computation for special holiday and regular holiday method to computes hours beyond 8, adjusting for next-day check-outs, and returns overtime rounded to two decimals.
![image](https://github.com/user-attachments/assets/0c96e9fd-cb6c-4f86-aba0-40a0b4d7e422)

